### PR TITLE
ensure correct ODBCVER is used

### DIFF
--- a/source/pdo_sqlsrv/xplat.h
+++ b/source/pdo_sqlsrv/xplat.h
@@ -228,6 +228,10 @@ typedef windowsULongLong_t ULONGLONG;
 #define UNIXODBC
 #endif
 
+/* can be defined in php sources */
+#ifdef  ODBCVER
+#undef  ODBCVER
+#endif
 // Build the mplat driver as an ODBC 3.8 driver, so that all of the
 // source code shared with Windows SNAC (which is ODBC 3.8) compiles.
 #define ODBCVER 0x0380

--- a/source/sqlsrv/xplat.h
+++ b/source/sqlsrv/xplat.h
@@ -228,6 +228,10 @@ typedef windowsULongLong_t ULONGLONG;
 #define UNIXODBC
 #endif
 
+/* can be defined in php sources */
+#ifdef  ODBCVER
+#undef  ODBCVER
+#endif
 // Build the mplat driver as an ODBC 3.8 driver, so that all of the
 // source code shared with Windows SNAC (which is ODBC 3.8) compiles.
 #define ODBCVER 0x0380


### PR DESCRIPTION
And to avoid build warning

```
/builddir/build/BUILD/php-sqlsrv-4.0.4/NTS/sqlsrv/xplat.h:233:0: warning: "ODBCVER" redefined [enabled by default]
 #define ODBCVER 0x0380
 ^
In file included from /usr/include/php/main/php_syslog.h:27:0,
                 from /usr/include/php/ext/standard/php_ext_syslog.h:26,
                 from /usr/include/php/ext/standard/php_standard.h:33,
                 from /builddir/build/BUILD/php-sqlsrv-4.0.4/NTS/sqlsrv/core_sqlsrv.h:37,
                 from /builddir/build/BUILD/php-sqlsrv-4.0.4/NTS/sqlsrv/core_init.cpp:20:
/usr/include/php/main/php_config.h:2168:0: note: this is the location of the previous definition
 #define ODBCVER 0x0300
 ^

```