### PR TITLE
fix buffer overflow, raising segfault in pdo driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,11 @@ Now you are ready to install PHP.
 
     2. Run `./configure` with the same options listed above, in addition to the following:
     
-      (i) `CXXFLAGS=-std=c++11` to ensure your compiler uses the C++11 standard. 
-      (ii) `--enable-sqlsrv=shared `
-      (iii)`--with-pdo_sqlsrv=shared` 
-      (iv)`--with-odbcver=0x0380`. This option has no practical effect as the drivers use ODBC version 3.52, but it suppresses compilation warnings arising from the fact that PHP's default setting of version 3.00 is different from unixODBC's setting of 3.80. 
+      (i) `--enable-sqlsrv=shared`
+      (ii) `--with-pdo_sqlsrv=shared`
+      (iii) `--with-odbcver=0x0380`. This option has no practical effect as the drivers use ODBC version 3.52, but it suppresses compilation warnings arising from the fact that PHP's default setting of version 3.00 is different from unixODBC's setting of 3.80.
 
-      Thus your `./configure` command should look like `./configure --with-apxs2=<path-to-apxs-executable> CXXFLAGS=-std=c++11 --enable-sqlsrv=shared --with-pdo_sqlsrv=shared --with-odbcver=0x0380`. 
+      Thus your `./configure` command should look like `./configure --with-apxs2=<path-to-apxs-executable> --enable-sqlsrv=shared --with-pdo_sqlsrv=shared --with-odbcver=0x0380`.
 
    3. Run `make`. The compiled drivers will be located in the `modules/` directory, and are named `sqlsrv.so` and `pdo_sqlsrv.so`.       
 
@@ -135,7 +134,7 @@ Now you are ready to install PHP.
 
     1. Switch to the source directory of the extension you want to install, e.g. `source/sqlsrv` or `source/pdo_sqlsrv`.
 
-    2. Run `phpize && ./configure CXXFLAGS=-std=c++11 && make` to compile the extension.
+    2. Run `phpize && ./configure && make` to compile the extension.
 
     3. Run `sudo make install` to install the binaries into the default php extensions directory.
 

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -361,7 +361,7 @@ struct pdo_dbh_methods pdo_sqlsrv_dbh_methods = {
 { \
     pdo_sqlsrv_dbh* driver_dbh = reinterpret_cast<pdo_sqlsrv_dbh*>( dbh->driver_data ); \
     driver_dbh->set_func( __FUNCTION__ ); \
-    int length = strlen(__FUNCTION__); \
+    int length = strlen(__FUNCTION__)+strlen(": entering"); \
     char func[length+1]; \
     LOG( SEV_NOTICE, strcat(strcpy(func, __FUNCTION__), ": entering")); \
 }

--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -339,7 +339,7 @@ void stmt_option_emulate_prepares:: operator()( sqlsrv_stmt* stmt, stmt_option c
 { \
     pdo_sqlsrv_stmt* driver_stmt = reinterpret_cast<pdo_sqlsrv_stmt*>( stmt->driver_data ); \
     driver_stmt->set_func( __FUNCTION__ ); \
-    int length = strlen(__FUNCTION__); \
+    int length = strlen(__FUNCTION__)+strlen(": entering"); \
     char func[length+1]; \
     LOG( SEV_NOTICE, strcat(strcpy(func, __FUNCTION__), ": entering")); \
 }
@@ -422,15 +422,7 @@ int pdo_sqlsrv_stmt_describe_col(pdo_stmt_t *stmt, int colno TSRMLS_DC)
 {
     PDO_RESET_STMT_ERROR;
     PDO_VALIDATE_STMT;
-#ifndef __linux__
     PDO_LOG_STMT_ENTRY;
-#else
-    pdo_sqlsrv_stmt* driver_stmtt = reinterpret_cast<pdo_sqlsrv_stmt*>( stmt->driver_data );
-    driver_stmtt->set_func( __FUNCTION__ );
-    int length = strlen(__FUNCTION__);
-    char func[length+1];
-    LOG( SEV_NOTICE, strcat(strcpy(func, __FUNCTION__), ": entering"));
-#endif
 
     SQLSRV_ASSERT(( colno >= 0 ), "pdo_sqlsrv_stmt_describe_col: Column number should be >= 0." );
 


### PR DESCRIPTION
Trying to run a simple request:
```

*** buffer overflow detected ***: /usr/bin/php terminated
======= Backtrace: =========
/lib64/libc.so.6(+0x77de5)[0x7ffff4ae1de5]
/lib64/libc.so.6(__fortify_fail+0x37)[0x7ffff4b7e167]
/lib64/libc.so.6(+0x1122f0)[0x7ffff4b7c2f0]
/lib64/libc.so.6(__strcat_chk+0x5d)[0x7ffff4b7b4dd]
/usr/lib64/php/modules/pdo_sqlsrv.so(_Z22pdo_sqlsrv_dbh_prepareP10_pdo_dbh_tPKcmP11_pdo_stmt_tP12_zval_struct+0x11b)[0x7fffb8626e4b]
/usr/lib64/php/modules/pdo.so(+0x81c4)[0x7fffdb87a1c4]
/usr/bin/php(dtrace_execute_internal+0x2a)[0x55555578edfa]
/usr/bin/php(+0x2d0230)[0x555555824230]
/usr/bin/php(execute_ex+0x1b)[0x5555557df37b]
/usr/bin/php(dtrace_execute_ex+0xb1)[0x55555578ec91]
/usr/lib64/php/modules/ioncube_loader.so(+0x77148)[0x7fffecb82148]
/usr/bin/php(zend_execute+0x1a7)[0x555555833817]
/usr/bin/php(zend_execute_scripts+0xc3)[0x55555579ef23]
/usr/bin/php(php_execute_script+0x2d0)[0x55555573eba0]
/usr/bin/php(+0x2e14e6)[0x5555558354e6]
/usr/bin/php(+0xccb96)[0x555555620b96]
/lib64/libc.so.6(__libc_start_main+0xf0)[0x7ffff4a8a580]
/usr/bin/php(_start+0x29)[0x555555620cd9]

```