### PR TITLE
Backport FETCHES_NUMERIC_TYPE and add FETCHES_DECIMAL_FLOAT

### DIFF
--- a/source/pdo_sqlsrv/core_sqlsrv.h
+++ b/source/pdo_sqlsrv/core_sqlsrv.h
@@ -1292,7 +1292,7 @@ struct sqlsrv_stmt : public sqlsrv_context {
     virtual ~sqlsrv_stmt( void );
 
     // driver specific conversion rules from a SQL Server/ODBC type to one of the SQLSRV_PHPTYPE_* constants
-    virtual sqlsrv_phptype sql_type_to_php_type( SQLINTEGER sql_type, SQLUINTEGER size, bool prefer_string_to_stream ) = 0;
+    virtual sqlsrv_phptype sql_type_to_php_type( SQLINTEGER sql_type, SQLUINTEGER size, bool prefer_string_to_stream, bool prefer_number_to_string = false, bool prefer_decimal_as_float = false ) = 0;
 
 };
 

--- a/source/pdo_sqlsrv/pdo_init.cpp
+++ b/source/pdo_sqlsrv/pdo_init.cpp
@@ -421,6 +421,8 @@ namespace {
         { "SQLSRV_ATTR_DIRECT_QUERY"        , SQLSRV_ATTR_DIRECT_QUERY },
         { "SQLSRV_ATTR_CURSOR_SCROLL_TYPE"  , SQLSRV_ATTR_CURSOR_SCROLL_TYPE },
         { "SQLSRV_ATTR_CLIENT_BUFFER_MAX_KB_SIZE", SQLSRV_ATTR_CLIENT_BUFFER_MAX_KB_SIZE },
+        { "SQLSRV_ATTR_FETCHES_NUMERIC_TYPE", SQLSRV_ATTR_FETCHES_NUMERIC_TYPE },
+        { "SQLSRV_ATTR_FETCHES_DECIMAL_FLOAT", SQLSRV_ATTR_FETCHES_DECIMAL_FLOAT },
 
         // used for the size for output parameters: PDO::PARAM_INT and PDO::PARAM_BOOL use the default size of int,
         // PDO::PARAM_STR uses the size of the string in the variable


### PR DESCRIPTION
Moving from PHP5.x's mssql_* functions to PDO::SQLSRV we've had a couple of compatibility issues.

I solved most of our issues by backporting SQLSRV_ATTR_FETCHES_NUMERIC_TYPE from 4.1.0 (Windows) and adding the ability to return Decimals (Money type) as Float (I know people typically prefer not to do this, for obvious reasons but this lets people be backwards compatible with data returned from mssql_* functions)