### PR TITLE
Php 7.0 linux

### DIFF
--- a/source/pdo_sqlsrv/pdo_init.cpp
+++ b/source/pdo_sqlsrv/pdo_init.cpp
@@ -19,7 +19,6 @@
 
 #include "php_pdo_sqlsrv.h"
 #ifdef __linux__
-#include <iostream>
 #include <dlfcn.h>
 #else
 #include <psapi.h>

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -20,7 +20,6 @@
 #include "core_sqlsrv.h"
 
 #include <functional>
-#include <iostream>
 #include <sstream>
 #include <type_traits>
 #include <uchar.h>


### PR DESCRIPTION
iostream not used and can be removed