### PR TITLE
Update Docker test file for odbc 13.1.3.0 release.

### DIFF
--- a/Dockerfile-msphpsql
+++ b/Dockerfile-msphpsql
@@ -20,6 +20,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
 	php7.0-dev \
 	python-pip \
 	re2c \
+        unixodbc-dev \
 	unzip && apt-get clean
 	
 ARG PHPSQLDIR=/REPO/msphpsql-PHP-7.0-Linux
@@ -34,7 +35,7 @@ RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt
 
 #RUN echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/mssql-ubuntu-xenial-release/ xenial main" > /etc/apt/sources.list.d/mssqlpreview.list
 #RUN apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
-RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools unixodbc-dev-utf16
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
 
 #install coveralls
 RUN pip install --upgrade pip && pip install cpp-coveralls

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Following instructions shows how to install PHP 7.x, Microsoft ODBC driver, apac
 	exit
 	sudo apt-get update
 	sudo ACCEPT_EULA=Y apt-get install msodbcsql mssql-tools
-	sudo apt-get install unixodbc-dev-utf16 
+	sudo apt-get install unixodbc-dev 
 
 	
 **Ubuntu 16.04**
@@ -113,7 +113,7 @@ Following instructions shows how to install PHP 7.x, Microsoft ODBC driver, apac
 	exit
 	sudo apt-get update
 	sudo ACCEPT_EULA=Y apt-get install msodbcsql mssql-tools 
-	sudo apt-get install unixodbc-dev-utf16
+	sudo apt-get install unixodbc-dev
 
 **RedHat 7**
 
@@ -121,9 +121,8 @@ Following instructions shows how to install PHP 7.x, Microsoft ODBC driver, apac
 	curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
 	exit
 	sudo yum update
-	sudo yum remove unixODBC #to avoid conflicts
 	sudo ACCEPT_EULA=Y yum install msodbcsql mssql-tools 
-	sudo yum install unixODBC-utf16-devel 
+	sudo yum install unixODBC-devel 
 
 
 


### PR DESCRIPTION
Specific unixodbc utf16 package is no longer required by odbc so
the regular unixodbc-dev package is used instead.