### PR TITLE
Don't forget to mention build-dependancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Following instructions shows how to install PHP 7.x, Microsoft ODBC driver, apac
 
 ### Step 4: Install the Microsoft PHP Drivers for SQL Server
 
+    sudo apt-get install php7.0-dev gcc g++ re2c
     sudo pecl install sqlsrv
     sudo pecl install pdo_sqlsrv
     


### PR DESCRIPTION
On a clean server, given the old instructions the pecl command will fail due to at least missing php7.0-dev (for phpize) and g++ (for cpp).

