### PR TITLE
Fix memory leaks in buffered resultsets.

### DIFF
--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -1484,7 +1484,7 @@ struct sqlsrv_buffered_result_set : public sqlsrv_result_set {
 
     HashTable* cache;                   // rows of data kept in index based hash table
     SQLSMALLINT col_count;            // number of columns in the current result set
-    meta_data* meta;                    // metadata for fields in the cache
+    sqlsrv_malloc_auto_ptr<meta_data> meta;  // metadata for fields in the cache
     SQLLEN current;                     // 1 based, 0 means before first row
     sqlsrv_error_auto_ptr last_error;   // if an error occurred, it is kept here
     SQLUSMALLINT last_field_index;      // the last field data retrieved from

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -208,7 +208,11 @@ void sqlsrv_stmt::new_result_set( TSRMLS_D )
 
     // create a new result set
     if( cursor_type == SQLSRV_CURSOR_BUFFERED ) {
-        current_results = new (sqlsrv_malloc( sizeof( sqlsrv_buffered_result_set ))) sqlsrv_buffered_result_set( this TSRMLS_CC );
+         sqlsrv_malloc_auto_ptr<sqlsrv_buffered_result_set> result;         
+        result = reinterpret_cast<sqlsrv_buffered_result_set*> ( sqlsrv_malloc( sizeof( sqlsrv_buffered_result_set ) ) );
+        new ( result.get() ) sqlsrv_buffered_result_set( this TSRMLS_CC );
+        current_results = result.get();        
+        result.transferred();
     }
     else {
         current_results = new (sqlsrv_malloc( sizeof( sqlsrv_odbc_result_set ))) sqlsrv_odbc_result_set( this );


### PR DESCRIPTION
- meta, row, cache, & current_results may leak.