### PR TITLE
fix crash from getting the numrow of a null buffered result set

### DIFF
--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -911,6 +911,7 @@ SQLLEN sqlsrv_buffered_result_set::row_count( TSRMLS_D )
 		return zend_hash_num_elements( cache );
 	}
 	else {
+		// returning -1 to represent getting the rowcount of an empty result set
 		return -1;
 	}
 }

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -907,7 +907,12 @@ SQLLEN sqlsrv_buffered_result_set::row_count( TSRMLS_D )
 {
     last_error = NULL;
 
-    return zend_hash_num_elements( cache );
+	if ( cache ) {
+		return zend_hash_num_elements( cache );
+	}
+	else {
+		return -1;
+	}
 }
 
 // private functions

--- a/test/sqlsrv/srv_330_numrow_null_buffered_result_set.phpt
+++ b/test/sqlsrv/srv_330_numrow_null_buffered_result_set.phpt
@@ -1,0 +1,31 @@
+--TEST--
+GitHub issue #330 - get numrow of null buffered result set
+--DESCRIPTION--
+A variation of the example in GitHub issue 330. A -1 value returned as numrow of a null buffered result set.
+--SKIPIF--
+--FILE--
+<?php
+require_once("tools.inc");
+
+require_once("autonomous_setup.php");
+
+// Connect
+$conn = sqlsrv_connect($serverName, $connectionInfo) ?: FatalError("Failed to connect");
+
+$stmt = sqlsrv_query($conn, "IF EXISTS (SELECT * FROM [sys].[objects] WHERE (name LIKE 'non_existent_table_name%') AND type in (N'U'))
+    BEGIN
+    select 0
+    END", [], ['Scrollable' => SQLSRV_CURSOR_CLIENT_BUFFERED]);
+
+if ($stmt) {
+    $hasRows = sqlsrv_has_rows($stmt);
+    $numRows = sqlsrv_num_rows($stmt);
+    echo "hasRows: ";
+    var_dump($hasRows);
+    echo "numRows: ";
+    var_dump($numRows);
+}
+?>
+--EXPECT--
+hasRows: bool(false)
+numRows: int(-1)


### PR DESCRIPTION
fit for #330
fix crash from sqlsrv_num_rows to get the numrow in a client buffered result set that is null
added test