### PR TITLE
rename stmt_option_scrollable to driver specific names

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -76,7 +76,7 @@ enum PDO_STMT_OPTIONS {
 const stmt_option PDO_STMT_OPTS[] = {
  
     { NULL, 0, SQLSRV_STMT_OPTION_QUERY_TIMEOUT, std::unique_ptr<stmt_option_query_timeout>( new stmt_option_query_timeout ) },
-    { NULL, 0, SQLSRV_STMT_OPTION_SCROLLABLE, std::unique_ptr<stmt_option_scrollable>( new stmt_option_scrollable ) },
+    { NULL, 0, SQLSRV_STMT_OPTION_SCROLLABLE, std::unique_ptr<stmt_option_pdo_scrollable>( new stmt_option_pdo_scrollable ) },
     { NULL, 0, PDO_STMT_OPTION_ENCODING, std::unique_ptr<stmt_option_encoding>( new stmt_option_encoding ) },
     { NULL, 0, PDO_STMT_OPTION_DIRECT_QUERY, std::unique_ptr<stmt_option_direct_query>( new stmt_option_direct_query ) },
     { NULL, 0, PDO_STMT_OPTION_CURSOR_SCROLL_TYPE, std::unique_ptr<stmt_option_cursor_scroll_type>( new stmt_option_cursor_scroll_type ) },

--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -305,7 +305,7 @@ struct pdo_stmt_methods pdo_sqlsrv_stmt_methods = {
 
 };
 
-void stmt_option_scrollable:: operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC )
+void stmt_option_pdo_scrollable:: operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC )
 {
     set_stmt_cursors( stmt, value_z TSRMLS_CC ); 
 }

--- a/source/pdo_sqlsrv/pdo_util.cpp
+++ b/source/pdo_sqlsrv/pdo_util.cpp
@@ -550,6 +550,8 @@ void pdo_sqlsrv_log( unsigned int severity TSRMLS_DC, const char* msg, va_list* 
 
 namespace {
 
+// Workaround for name collision problem between the SQLSRV and PDO_SQLSRV drivers on Mac
+// Place get_error_message into the anonymous namespace in pdo_util.cpp
 sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code) {
 
 	sqlsrv_error_const *error_message = NULL;

--- a/source/pdo_sqlsrv/pdo_util.cpp
+++ b/source/pdo_sqlsrv/pdo_util.cpp
@@ -42,6 +42,9 @@ char log_msg[ LOG_MSG_SIZE ];
 // internal error that says that FormatMessage failed
 SQLCHAR INTERNAL_FORMAT_ERROR[] = "An internal error occurred.  FormatMessage failed writing an error message.";
 
+// Returns a sqlsrv_error for a given error code.
+sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code);
+
 // build the object and throw the PDO exception
 void pdo_sqlsrv_throw_exception( sqlsrv_error_const* error TSRMLS_DC );
 
@@ -373,20 +376,6 @@ pdo_error PDO_ERRORS[] = {
     { UINT_MAX, {} }
 };
 
-// Returns a sqlsrv_error for a given error code.
-sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code) {
-
-    sqlsrv_error_const *error_message = NULL;
-    int zr = (error_message = reinterpret_cast<sqlsrv_error_const*>(zend_hash_index_find_ptr(g_pdo_errors_ht, sqlsrv_error_code))) != NULL ? SUCCESS : FAILURE;
-    if( zr == FAILURE ) {
-        DIE( "get_error_message: zend_hash_index_find returned failure for sqlsrv_error_code = %1!d!", sqlsrv_error_code );   
-    }
-    
-    SQLSRV_ASSERT( error_message != NULL, "get_error_message: error_message was null");
-
-    return error_message;
-}
-
 // PDO error handler for the environment context.
 bool pdo_sqlsrv_handle_env_error( sqlsrv_context& ctx, unsigned int sqlsrv_error_code, bool warning TSRMLS_DC, 
                                   va_list* print_args )
@@ -560,6 +549,19 @@ void pdo_sqlsrv_log( unsigned int severity TSRMLS_DC, const char* msg, va_list* 
 }
 
 namespace {
+
+sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code) {
+
+	sqlsrv_error_const *error_message = NULL;
+	int zr = (error_message = reinterpret_cast<sqlsrv_error_const*>(zend_hash_index_find_ptr(g_pdo_errors_ht, sqlsrv_error_code))) != NULL ? SUCCESS : FAILURE;
+	if (zr == FAILURE) {
+		DIE("get_error_message: zend_hash_index_find returned failure for sqlsrv_error_code = %1!d!", sqlsrv_error_code);
+	}
+
+	SQLSRV_ASSERT(error_message != NULL, "get_error_message: error_message was null");
+
+	return error_message;
+}
 
 void pdo_sqlsrv_throw_exception( sqlsrv_error_const* error TSRMLS_DC )
 {

--- a/source/pdo_sqlsrv/php_pdo_sqlsrv.h
+++ b/source/pdo_sqlsrv/php_pdo_sqlsrv.h
@@ -194,7 +194,7 @@ struct stmt_option_encoding : public stmt_option_functor {
     virtual void operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC );
 };
 
-struct stmt_option_scrollable : public stmt_option_functor {
+struct stmt_option_pdo_scrollable : public stmt_option_functor {
 
     virtual void operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC );
 };

--- a/source/sqlsrv/conn.cpp
+++ b/source/sqlsrv/conn.cpp
@@ -210,7 +210,7 @@ const stmt_option SS_STMT_OPTS[] = {
         SSStmtOptionNames::SCROLLABLE, 
         sizeof( SSStmtOptionNames::SCROLLABLE ),
         SQLSRV_STMT_OPTION_SCROLLABLE, 
-	    std::unique_ptr<stmt_option_scrollable>( new stmt_option_scrollable )
+	    std::unique_ptr<stmt_option_ss_scrollable>( new stmt_option_ss_scrollable )
     },
     { 
         SSStmtOptionNames::CLIENT_BUFFER_MAX_SIZE, 

--- a/source/sqlsrv/php_sqlsrv.h
+++ b/source/sqlsrv/php_sqlsrv.h
@@ -160,7 +160,7 @@ struct sqlsrv_fetch_field_name {
     unsigned int len;
 };
 
-struct stmt_option_scrollable : public stmt_option_functor {
+struct stmt_option_ss_scrollable : public stmt_option_functor {
 
     virtual void operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC );
 };

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -1444,7 +1444,7 @@ PHP_FUNCTION( sqlsrv_free_stmt )
     }
 }
 
-void stmt_option_scrollable:: operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC )
+void stmt_option_ss_scrollable:: operator()( sqlsrv_stmt* stmt, stmt_option const* /*opt*/, zval* value_z TSRMLS_DC )
 {
     CHECK_CUSTOM_ERROR(( Z_TYPE_P( value_z ) != IS_STRING ), stmt, SQLSRV_ERROR_INVALID_OPTION_SCROLLABLE ) {
         throw ss::SSException();

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -34,6 +34,8 @@ char log_msg[ LOG_MSG_SIZE ];
 SQLCHAR INTERNAL_FORMAT_ERROR[] = "An internal error occurred.  FormatMessage failed writing an error message.";
 
 // *** internal functions ***
+sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code);
+
 void copy_error_to_zval( zval* error_z, sqlsrv_error_const* error, zval* reported_chain, zval* ignored_chain, 
                                 bool warning TSRMLS_DC );
 bool ignore_warning( char* sql_state, int native_code TSRMLS_DC );
@@ -375,20 +377,6 @@ ss_error SS_ERRORS[] = {
     { UINT_MAX, {} }
 };
 
-sqlsrv_error_const* get_error_message( unsigned int sqlsrv_error_code ) {
-    
-    sqlsrv_error_const *error_message = NULL;
-	
-	int zr = (error_message = reinterpret_cast<sqlsrv_error_const*>(zend_hash_index_find_ptr( g_ss_errors_ht, sqlsrv_error_code)))  != NULL ? SUCCESS : FAILURE;
-    if( zr == FAILURE ) {
-        DIE( "get_error_message: zend_hash_index_find returned failure for sqlsrv_error_code = %1!d!", sqlsrv_error_code );   
-    }
-    
-    SQLSRV_ASSERT( error_message != NULL, "get_error_message: error_message was null");
-
-    return error_message;
-}
-
 // Formats an error message and finally writes it to the php log.
 void ss_sqlsrv_log( unsigned int severity TSRMLS_DC, const char* msg, va_list* print_args )
 {
@@ -691,6 +679,20 @@ PHP_FUNCTION( sqlsrv_get_config )
 
 
 namespace {
+
+sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code) {
+
+	sqlsrv_error_const *error_message = NULL;
+
+	int zr = (error_message = reinterpret_cast<sqlsrv_error_const*>(zend_hash_index_find_ptr(g_ss_errors_ht, sqlsrv_error_code))) != NULL ? SUCCESS : FAILURE;
+	if (zr == FAILURE) {
+		DIE("get_error_message: zend_hash_index_find returned failure for sqlsrv_error_code = %1!d!", sqlsrv_error_code);
+	}
+
+	SQLSRV_ASSERT(error_message != NULL, "get_error_message: error_message was null");
+
+	return error_message;
+}
 
 void copy_error_to_zval( zval* error_z, sqlsrv_error_const* error, zval* reported_chain, zval* ignored_chain, 
                          bool warning TSRMLS_DC )

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -34,7 +34,7 @@ char log_msg[ LOG_MSG_SIZE ];
 SQLCHAR INTERNAL_FORMAT_ERROR[] = "An internal error occurred.  FormatMessage failed writing an error message.";
 
 // *** internal functions ***
-sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code);
+sqlsrv_error_const* get_error_message( unsigned int sqlsrv_error_code );
 
 void copy_error_to_zval( zval* error_z, sqlsrv_error_const* error, zval* reported_chain, zval* ignored_chain, 
                                 bool warning TSRMLS_DC );
@@ -680,16 +680,16 @@ PHP_FUNCTION( sqlsrv_get_config )
 
 namespace {
 
-sqlsrv_error_const* get_error_message(unsigned int sqlsrv_error_code) {
+sqlsrv_error_const* get_error_message( unsigned int sqlsrv_error_code ) {
 
 	sqlsrv_error_const *error_message = NULL;
 
-	int zr = (error_message = reinterpret_cast<sqlsrv_error_const*>(zend_hash_index_find_ptr(g_ss_errors_ht, sqlsrv_error_code))) != NULL ? SUCCESS : FAILURE;
-	if (zr == FAILURE) {
-		DIE("get_error_message: zend_hash_index_find returned failure for sqlsrv_error_code = %1!d!", sqlsrv_error_code);
+	int zr = ( error_message = reinterpret_cast< sqlsrv_error_const* >( zend_hash_index_find_ptr( g_ss_errors_ht, sqlsrv_error_code ))) != NULL ? SUCCESS : FAILURE;
+	if ( zr == FAILURE ) {
+		DIE( "get_error_message: zend_hash_index_find returned failure for sqlsrv_error_code = %1!d!", sqlsrv_error_code );
 	}
 
-	SQLSRV_ASSERT(error_message != NULL, "get_error_message: error_message was null");
+	SQLSRV_ASSERT( error_message != NULL, "get_error_message: error_message was null" );
 
 	return error_message;
 }

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -680,6 +680,8 @@ PHP_FUNCTION( sqlsrv_get_config )
 
 namespace {
 
+// Workaround for name collision problem between the SQLSRV and PDO_SQLSRV drivers on Mac
+// Place get_error_message into the anonymous namespace in util.cpp
 sqlsrv_error_const* get_error_message( unsigned int sqlsrv_error_code ) {
 
 	sqlsrv_error_const *error_message = NULL;


### PR DESCRIPTION
Rename stmt_opton_scrollable to driver specific names (stmt_option_ss_scrollable and stmt_option_pdo_scrollable)P
ut get_eror_message into namespace (util.cpp and pdo_util.cpp)