### PR TITLE
convert const char[] to char[] to avoid conversion warnings

### DIFF
--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -636,14 +636,14 @@ PHP_RINIT_FUNCTION(sqlsrv)
     LOG_FUNCTION( "PHP_RINIT for php_sqlsrv" );
 
     // read INI settings
-	// need to convert const char[] to char[] to avoid converting string to char* warnings
-	// cannot simply cast const char[] to char* since INI_INT needs the sizeof(param) and the size of char* is always 4 / 8 bytes
-	char warnings_as_errors[] = INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS;
-	char severity[] = INI_PREFIX INI_LOG_SEVERITY;
-	char subsystems[] = INI_PREFIX INI_LOG_SUBSYSTEMS;
-	char buffered_limit[] = INI_PREFIX INI_BUFFERED_QUERY_LIMIT;
+    // need to convert const char[] to char[] to avoid converting string to char* warnings
+    // cannot simply cast const char[] to char* since INI_INT needs the sizeof(param) and the size of char* is always 4 / 8 bytes
+    char warnings_as_errors[] = INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS;
+    char severity[] = INI_PREFIX INI_LOG_SEVERITY;
+    char subsystems[] = INI_PREFIX INI_LOG_SUBSYSTEMS;
+    char buffered_limit[] = INI_PREFIX INI_BUFFERED_QUERY_LIMIT;
     
-	SQLSRV_G( warnings_return_as_errors ) = INI_BOOL( INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS );
+    SQLSRV_G( warnings_return_as_errors ) = INI_BOOL( INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS );
     SQLSRV_G( log_severity ) = INI_INT( INI_PREFIX INI_LOG_SEVERITY );
     SQLSRV_G( log_subsystems ) = INI_INT( INI_PREFIX INI_LOG_SUBSYSTEMS );
     SQLSRV_G( buffered_query_limit ) = INI_INT( INI_PREFIX INI_BUFFERED_QUERY_LIMIT );

--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -636,7 +636,14 @@ PHP_RINIT_FUNCTION(sqlsrv)
     LOG_FUNCTION( "PHP_RINIT for php_sqlsrv" );
 
     // read INI settings
-    SQLSRV_G( warnings_return_as_errors ) = INI_BOOL( INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS );
+	// need to convert const char[] to char[] to avoid converting string to char* warnings
+	// cannot simply cast const char[] to char* since INI_INT needs the sizeof(param) and the size of char* is always 4 / 8 bytes
+	char warnings_as_errors[] = INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS;
+	char severity[] = INI_PREFIX INI_LOG_SEVERITY;
+	char subsystems[] = INI_PREFIX INI_LOG_SUBSYSTEMS;
+	char buffered_limit[] = INI_PREFIX INI_BUFFERED_QUERY_LIMIT;
+    
+	SQLSRV_G( warnings_return_as_errors ) = INI_BOOL( INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS );
     SQLSRV_G( log_severity ) = INI_INT( INI_PREFIX INI_LOG_SEVERITY );
     SQLSRV_G( log_subsystems ) = INI_INT( INI_PREFIX INI_LOG_SUBSYSTEMS );
     SQLSRV_G( buffered_query_limit ) = INI_INT( INI_PREFIX INI_BUFFERED_QUERY_LIMIT );

--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -643,10 +643,10 @@ PHP_RINIT_FUNCTION(sqlsrv)
     char subsystems[] = INI_PREFIX INI_LOG_SUBSYSTEMS;
     char buffered_limit[] = INI_PREFIX INI_BUFFERED_QUERY_LIMIT;
     
-    SQLSRV_G( warnings_return_as_errors ) = INI_BOOL( INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS );
-    SQLSRV_G( log_severity ) = INI_INT( INI_PREFIX INI_LOG_SEVERITY );
-    SQLSRV_G( log_subsystems ) = INI_INT( INI_PREFIX INI_LOG_SUBSYSTEMS );
-    SQLSRV_G( buffered_query_limit ) = INI_INT( INI_PREFIX INI_BUFFERED_QUERY_LIMIT );
+    SQLSRV_G( warnings_return_as_errors ) = INI_BOOL( warnings_as_errors );
+    SQLSRV_G( log_severity ) = INI_INT( severity );
+    SQLSRV_G( log_subsystems ) = INI_INT( subsystems );
+    SQLSRV_G( buffered_query_limit ) = INI_INT( buffered_limit );
 
     LOG( SEV_NOTICE, INI_PREFIX INI_WARNINGS_RETURN_AS_ERRORS " = %1!s!", SQLSRV_G( warnings_return_as_errors ) ? "On" : "Off");
     LOG( SEV_NOTICE, INI_PREFIX INI_LOG_SEVERITY " = %1!d!", SQLSRV_G( log_severity ));


### PR DESCRIPTION
#332 