### PR TITLE
rename g_henv_cp and g_henv_ncp to g_pdo_henv_.. and gg_ss_henv_.. to…

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -467,14 +467,14 @@ int pdo_sqlsrv_db_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_DC)
     // to happen (per the PDO spec)
     dbh->error_mode = PDO_ERRMODE_EXCEPTION;
 
-    g_henv_cp->set_driver( dbh );
-    g_henv_ncp->set_driver( dbh );
+    g_pdo_henv_cp->set_driver( dbh );
+    g_pdo_henv_ncp->set_driver( dbh );
 
-    CHECK_CUSTOM_ERROR( driver_options && Z_TYPE_P( driver_options ) != IS_ARRAY, *g_henv_cp, SQLSRV_ERROR_CONN_OPTS_WRONG_TYPE ) {
+    CHECK_CUSTOM_ERROR( driver_options && Z_TYPE_P( driver_options ) != IS_ARRAY, *g_pdo_henv_cp, SQLSRV_ERROR_CONN_OPTS_WRONG_TYPE ) {
         throw core::CoreException();
     }
 	// throws PDOException if the ATTR_PERSISTENT is in connection options
-	CHECK_CUSTOM_ERROR( dbh->is_persistent, *g_henv_cp, PDO_SQLSRV_ERROR_UNSUPPORTED_DBH_ATTR ) {
+	CHECK_CUSTOM_ERROR( dbh->is_persistent, *g_pdo_henv_cp, PDO_SQLSRV_ERROR_UNSUPPORTED_DBH_ATTR ) {
 		dbh->refcount--;
 		throw pdo::PDOException();
 	}
@@ -482,18 +482,18 @@ int pdo_sqlsrv_db_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_DC)
     // Initialize the options array to be passed to the core layer
     ALLOC_HASHTABLE( pdo_conn_options_ht );
 
-    core::sqlsrv_zend_hash_init( *g_henv_cp, pdo_conn_options_ht, 10 /* # of buckets */, 
+    core::sqlsrv_zend_hash_init( *g_pdo_henv_cp, pdo_conn_options_ht, 10 /* # of buckets */, 
                                  ZVAL_INTERNAL_DTOR, 0 /*persistent*/ TSRMLS_CC );
 
-    // Either of g_henv_cp or g_henv_ncp can be used to propogate the error.
-    dsn_parser = new ( sqlsrv_malloc( sizeof( conn_string_parser ))) conn_string_parser( *g_henv_cp, dbh->data_source, 
+    // Either of g_pdo_henv_cp or g_pdo_henv_ncp can be used to propogate the error.
+    dsn_parser = new ( sqlsrv_malloc( sizeof( conn_string_parser ))) conn_string_parser( *g_pdo_henv_cp, dbh->data_source, 
                                                                                           static_cast<int>( dbh->data_source_len ), pdo_conn_options_ht );
     dsn_parser->parse_conn_string( TSRMLS_C );
     
     // Extract the server name
     temp_server_z = zend_hash_index_find( pdo_conn_options_ht, PDO_CONN_OPTION_SERVER);
 
-    CHECK_CUSTOM_ERROR(( temp_server_z == NULL ), g_henv_cp, PDO_SQLSRV_ERROR_SERVER_NOT_SPECIFIED ) {
+    CHECK_CUSTOM_ERROR(( temp_server_z == NULL ), g_pdo_henv_cp, PDO_SQLSRV_ERROR_SERVER_NOT_SPECIFIED ) {
         
         throw pdo::PDOException();
     }
@@ -504,7 +504,7 @@ int pdo_sqlsrv_db_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_DC)
     zval_add_ref( &server_z );
     zend_hash_index_del( pdo_conn_options_ht, PDO_CONN_OPTION_SERVER );
 
-    sqlsrv_conn* conn = core_sqlsrv_connect( *g_henv_cp, *g_henv_ncp, core::allocate_conn<pdo_sqlsrv_dbh>, Z_STRVAL( server_z ), 
+    sqlsrv_conn* conn = core_sqlsrv_connect( *g_pdo_henv_cp, *g_pdo_henv_ncp, core::allocate_conn<pdo_sqlsrv_dbh>, Z_STRVAL( server_z ), 
                                              dbh->username, dbh->password, pdo_conn_options_ht, pdo_sqlsrv_handle_dbh_error, 
                                              PDO_CONN_OPTS, dbh, "pdo_sqlsrv_db_handle_factory" TSRMLS_CC );
 
@@ -526,7 +526,7 @@ int pdo_sqlsrv_db_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_DC)
             zend_string_release( Z_STR( server_z ));
         }
         dbh->error_mode = prev_err_mode;    // reset the error mode
-        g_henv_cp->last_error().reset();    // reset the last error; callee will check if last_error exist before freeing it and setting it to NULL
+        g_pdo_henv_cp->last_error().reset();    // reset the last error; callee will check if last_error exist before freeing it and setting it to NULL
         
         return 0;
     }
@@ -605,7 +605,7 @@ int pdo_sqlsrv_dbh_prepare( pdo_dbh_t *dbh, const char *sql,
         core::sqlsrv_zend_hash_init( *driver_dbh , pdo_stmt_options_ht, 3 /* # of buckets */, 
                                      ZVAL_PTR_DTOR, 0 /*persistent*/ TSRMLS_CC );
         
-        // Either of g_henv_cp or g_henv_ncp can be used to propogate the error.
+        // Either of g_pdo_henv_cp or g_pdo_henv_ncp can be used to propogate the error.
         validate_stmt_options( *driver_dbh, driver_options, pdo_stmt_options_ht TSRMLS_CC );
 
         driver_stmt = static_cast<pdo_sqlsrv_stmt*>( core_sqlsrv_create_stmt( driver_dbh, core::allocate_stmt<pdo_sqlsrv_stmt>,

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -491,7 +491,7 @@ int pdo_sqlsrv_db_handle_factory(pdo_dbh_t *dbh, zval *driver_options TSRMLS_DC)
     dsn_parser->parse_conn_string( TSRMLS_C );
     
     // Extract the server name
-    temp_server_z = zend_hash_index_find( pdo_conn_options_ht, PDO_CONN_OPTION_SERVER);
+    temp_server_z = zend_hash_index_find( pdo_conn_options_ht, PDO_CONN_OPTION_SERVER );
 
     CHECK_CUSTOM_ERROR(( temp_server_z == NULL ), g_pdo_henv_cp, PDO_SQLSRV_ERROR_SERVER_NOT_SPECIFIED ) {
         

--- a/source/pdo_sqlsrv/pdo_init.cpp
+++ b/source/pdo_sqlsrv/pdo_init.cpp
@@ -34,8 +34,8 @@ ZEND_DECLARE_MODULE_GLOBALS(pdo_sqlsrv);
 HashTable* g_pdo_errors_ht = NULL;
 
 // henv context for creating connections
-sqlsrv_context* g_henv_cp;
-sqlsrv_context* g_henv_ncp;
+sqlsrv_context* g_pdo_henv_cp;
+sqlsrv_context* g_pdo_henv_ncp;
 
 namespace {
 
@@ -159,7 +159,7 @@ PHP_MINIT_FUNCTION(pdo_sqlsrv)
     REGISTER_PDO_SQLSRV_CLASS_CONST_STRING( "SQLSRV_TXN_SNAPSHOT", PDOTxnIsolationValues::SNAPSHOT TSRMLS_CC );
 
     // retrieve the handles for the environments
-    core_sqlsrv_minit( &g_henv_cp, &g_henv_ncp, pdo_sqlsrv_handle_env_error, "PHP_MINIT_FUNCTION for pdo_sqlsrv" TSRMLS_CC );
+    core_sqlsrv_minit( &g_pdo_henv_cp, &g_pdo_henv_ncp, pdo_sqlsrv_handle_env_error, "PHP_MINIT_FUNCTION for pdo_sqlsrv" TSRMLS_CC );
 
     }
     catch( ... ) {
@@ -189,7 +189,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_sqlsrv)
         zend_hash_destroy( g_pdo_errors_ht );
         pefree( g_pdo_errors_ht, 1 /*persistent*/ );
 
-        core_sqlsrv_mshutdown( *g_henv_cp, *g_henv_ncp );
+        core_sqlsrv_mshutdown( *g_pdo_henv_cp, *g_pdo_henv_ncp );
 
     }
     catch( ... ) {

--- a/source/pdo_sqlsrv/php_pdo_sqlsrv.h
+++ b/source/pdo_sqlsrv/php_pdo_sqlsrv.h
@@ -99,8 +99,8 @@ PHP_INI_BEGIN()
 PHP_INI_END()
 
 // henv context for creating connections
-extern sqlsrv_context* g_henv_cp;
-extern sqlsrv_context* g_henv_ncp;
+extern sqlsrv_context* g_pdo_henv_cp;
+extern sqlsrv_context* g_pdo_henv_ncp;
 
 
 //*********************************************************************************************************************************

--- a/source/sqlsrv/conn.cpp
+++ b/source/sqlsrv/conn.cpp
@@ -455,8 +455,8 @@ PHP_FUNCTION ( sqlsrv_connect )
 {
     
     LOG_FUNCTION( "sqlsrv_connect" );
-    SET_FUNCTION_NAME( *g_henv_cp );
-    SET_FUNCTION_NAME( *g_henv_ncp );
+    SET_FUNCTION_NAME( *g_ss_henv_cp );
+    SET_FUNCTION_NAME( *g_ss_henv_ncp );
 
     reset_errors( TSRMLS_C );
 
@@ -470,7 +470,7 @@ PHP_FUNCTION ( sqlsrv_connect )
     // get the server name and connection options
     int result = zend_parse_parameters( ZEND_NUM_ARGS() TSRMLS_CC, "s|a", &server, &server_len, &options_z );
     
-    CHECK_CUSTOM_ERROR(( result == FAILURE ), *g_henv_cp, SS_SQLSRV_ERROR_INVALID_FUNCTION_PARAMETER, "sqlsrv_connect" ) {
+    CHECK_CUSTOM_ERROR(( result == FAILURE ), *g_ss_henv_cp, SS_SQLSRV_ERROR_INVALID_FUNCTION_PARAMETER, "sqlsrv_connect" ) {
         RETURN_FALSE;
     }
     
@@ -483,14 +483,14 @@ PHP_FUNCTION ( sqlsrv_connect )
         // Initialize the options array to be passed to the core layer
         ALLOC_HASHTABLE( ss_conn_options_ht );
         
-        core::sqlsrv_zend_hash_init( *g_henv_cp, ss_conn_options_ht, 10 /* # of buckets */, 
+        core::sqlsrv_zend_hash_init( *g_ss_henv_cp, ss_conn_options_ht, 10 /* # of buckets */, 
                                  ZVAL_PTR_DTOR, 0 /*persistent*/ TSRMLS_CC );
    
-        // Either of g_henv_cp or g_henv_ncp can be used to propogate the error.
-        ::validate_conn_options( *g_henv_cp, options_z, &uid, &pwd, ss_conn_options_ht TSRMLS_CC );   
+        // Either of g_ss_henv_cp or g_ss_henv_ncp can be used to propogate the error.
+        ::validate_conn_options( *g_ss_henv_cp, options_z, &uid, &pwd, ss_conn_options_ht TSRMLS_CC );   
      
         // call the core connect function  
-        conn = static_cast<ss_sqlsrv_conn*>( core_sqlsrv_connect( *g_henv_cp, *g_henv_ncp, &core::allocate_conn<ss_sqlsrv_conn>,
+        conn = static_cast<ss_sqlsrv_conn*>( core_sqlsrv_connect( *g_ss_henv_cp, *g_ss_henv_ncp, &core::allocate_conn<ss_sqlsrv_conn>,
                                                                   server, uid, pwd, ss_conn_options_ht, ss_error_handler,  
                                                                   SS_CONN_OPTS, NULL, "sqlsrv_connect" TSRMLS_CC )); 
         
@@ -499,7 +499,7 @@ PHP_FUNCTION ( sqlsrv_connect )
         // create a bunch of statements
         ALLOC_HASHTABLE( stmts );
     
-        core::sqlsrv_zend_hash_init( *g_henv_cp, stmts, 5, NULL /* dtor */, 0 /* persistent */ TSRMLS_CC );
+        core::sqlsrv_zend_hash_init( *g_ss_henv_cp, stmts, 5, NULL /* dtor */, 0 /* persistent */ TSRMLS_CC );
 
         // register the connection with the PHP runtime 
         

--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -41,8 +41,8 @@ void sqlsrv_error_const_dtor( zval* element );
 void sqlsrv_encoding_dtor( zval* element );
 
 // henv context for creating connections
-sqlsrv_context* g_henv_cp;
-sqlsrv_context* g_henv_ncp;
+sqlsrv_context* g_ss_henv_cp;
+sqlsrv_context* g_ss_henv_ncp;
 
 namespace {
 
@@ -552,7 +552,7 @@ PHP_MINIT_FUNCTION(sqlsrv)
 
     try {
         // retrieve the handles for the environments
-        core_sqlsrv_minit( &g_henv_cp, &g_henv_ncp, ss_error_handler, "PHP_MINIT_FUNCTION for sqlsrv" TSRMLS_CC );
+        core_sqlsrv_minit( &g_ss_henv_cp, &g_ss_henv_ncp, ss_error_handler, "PHP_MINIT_FUNCTION for sqlsrv" TSRMLS_CC );
     }
 
     catch( core::CoreException& ) {
@@ -602,7 +602,7 @@ PHP_MSHUTDOWN_FUNCTION(sqlsrv)
     zend_hash_destroy( g_ss_encodings_ht );
     pefree( g_ss_encodings_ht, 1 );
 
-    core_sqlsrv_mshutdown( *g_henv_cp, *g_henv_ncp );
+    core_sqlsrv_mshutdown( *g_ss_henv_cp, *g_ss_henv_ncp );
 
     if( php_unregister_url_stream_wrapper( SQLSRV_STREAM_WRAPPER TSRMLS_CC ) == FAILURE ) {
         return FAILURE;

--- a/source/sqlsrv/php_sqlsrv.h
+++ b/source/sqlsrv/php_sqlsrv.h
@@ -96,8 +96,8 @@ extern zend_module_entry g_sqlsrv_module_entry;   // describes the extension to 
 extern HMODULE g_sqlsrv_hmodule;                  // used for getting the version information
 
 // henv context for creating connections
-extern sqlsrv_context* g_henv_cp;
-extern sqlsrv_context* g_henv_ncp;
+extern sqlsrv_context* g_ss_henv_cp;
+extern sqlsrv_context* g_ss_henv_ncp;
 
 extern OSVERSIONINFO g_osversion;                 // used to determine which OS we're running in
 


### PR DESCRIPTION
rename g_henv_cp and g_henv_ncp to g_pdo_henv_.. and gg_ss_henv_.. to prevent name clashing problem in the pdo_sqlsrv and sqlsrv drivers In Mac