### PR TITLE
Removed extraneous null terminator that caused Address Sanitizer to c…

### DIFF
--- a/source/shared/StringFunctions.cpp
+++ b/source/shared/StringFunctions.cpp
@@ -136,7 +136,6 @@ int mplat_strcat_s( char * dest, size_t destSize, const char * src )
         errno = ERANGE;
         return ERANGE;
     }
-    *p = 0;
     return 0;
 }
 //


### PR DESCRIPTION
The assignment statement that I have removed wrote past the end of the array, causing Address Sanitizer to complain about a stack buffer overflow. In the previous while loop, we already copy the null terminator but p is incremented beyond that, which was causing the buffer overflow.