### PR TITLE
extracted select output param into a different test

### DIFF
--- a/test/pdo_sqlsrv/pdo_param_output_select_variant.phpt
+++ b/test/pdo_sqlsrv/pdo_param_output_select_variant.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Test parametrized insert and sql_variant as an output parameter.
+Test sql_variant as an output parameter 
 --DESCRIPTION--
-parameterized queries is not supported for Sql_Variant columns, this test, verifies a proper error message is returned  
+Since output param is not supported for sql_variant columns, this test verifies a proper error message is returned  
 --FILE--
 ﻿<?php
 include 'MsCommon.inc';

--- a/test/pdo_sqlsrv/pdo_param_output_select_variant.phpt
+++ b/test/pdo_sqlsrv/pdo_param_output_select_variant.phpt
@@ -1,0 +1,85 @@
+--TEST--
+Test parametrized insert and sql_variant as an output parameter.
+--DESCRIPTION--
+parameterized queries is not supported for Sql_Variant columns, this test, verifies a proper error message is returned  
+--FILE--
+﻿<?php
+include 'MsCommon.inc';
+
+function TestSimpleSelect($conn, $tableName)
+{
+    $count = 0;  
+
+    $stmt = $conn->prepare("SELECT ? = COUNT(* ) FROM $tableName");  
+    $stmt->bindParam( 1, $count, PDO::PARAM_INT, 4 );  
+    $stmt->execute();  
+    echo "Number of rows: $count\n";  
+
+    $value = 'xx';
+    
+    $stmt = $conn->prepare("SELECT ? = c2_variant FROM $tableName");  
+    $stmt->bindParam( 1, $value, PDO::PARAM_STR, 50 );  
+    $stmt->execute();  
+    echo "Variant column: $value\n\n";  
+    
+}
+
+function CreateVariantTable($conn, $tableName)
+{
+    try 
+    {
+        $stmt = $conn->exec("CREATE TABLE [$tableName] ([c1_int] int, [c2_variant] sql_variant)");    
+    }
+    catch (Exception $e)
+    {
+        echo "Failed to create a test table\n";
+        echo $e->getMessage();
+    }        
+
+    $tsql = "INSERT INTO [$tableName] ([c1_int], [c2_variant]) VALUES (1, ?)";    
+    
+    $data = "This is to test if sql_variant works with output parameters";
+    
+    $stmt = $conn->prepare($tsql);
+    $result = $stmt->execute(array($data));
+    if (! $result)
+        echo "Failed to insert data\n";
+}
+
+function RunTest()
+{
+    StartTest("pdo_param_output_select_variant");
+    try
+    {
+        include("MsSetup.inc");
+        // Connect
+        $conn = new PDO( "sqlsrv:server=$server;Database=$databaseName", $uid, $pwd);
+        $conn->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+        echo "\n";
+
+        // Now test with another stored procedure
+        $tableName = GetTempTableName();   
+        CreateVariantTable($conn, $tableName);
+
+        // Test a simple select to get output
+        TestSimpleSelect($conn, $tableName);
+        
+        $conn = null;
+    }
+    catch (Exception $e)
+    {
+        echo $e->getMessage();
+    }
+    echo "\nDone\n";
+    EndTest("pdo_param_output_select_variant");
+}
+
+RunTest();
+
+?>
+--EXPECT--
+﻿
+Number of rows: 1
+SQLSTATE[42000]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Implicit conversion from data type sql_variant to nvarchar(max) is not allowed. Use the CONVERT function to run this query.
+Done
+Test "pdo_param_output_select_variant" completed successfully.

--- a/test/pdo_sqlsrv/pdo_param_output_variants.phpt
+++ b/test/pdo_sqlsrv/pdo_param_output_variants.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test parametrized insert and sql_variant as an output parameter.
 --DESCRIPTION--
-parameterized queries is not supported for Sql_Variant columns, this test, verifies a proper error message is returned  
+Since output param is not supported for sql_variant columns, this test verifies a proper error message is returned  
 --FILE--
 ﻿<?php
 include 'MsCommon.inc';

--- a/test/pdo_sqlsrv/pdo_param_output_variants.phpt
+++ b/test/pdo_sqlsrv/pdo_param_output_variants.phpt
@@ -6,24 +6,6 @@ parameterized queries is not supported for Sql_Variant columns, this test, verif
 ﻿<?php
 include 'MsCommon.inc';
 
-function TestSimpleSelect($conn)
-{
-    $value = 0;  
-
-    $stmt = $conn->prepare("SELECT ? = COUNT(* ) FROM cd_info");  
-    $stmt->bindParam( 1, $value, PDO::PARAM_INT, 4 );  
-    $stmt->execute();  
-    echo "Number of items: $value\n";  
-
-    $title = 'xx';
-    
-    $stmt = $conn->prepare("SELECT ? = title FROM cd_info WHERE artist LIKE 'Led%'");  
-    $stmt->bindParam( 1, $title, PDO::PARAM_STR, 25 );  
-    $stmt->execute();  
-    echo "CD Title: $title\n\n";  
-    
-}
-
 function TestReverse($conn)
 {
     $procName = GetTempProcName('sqlReverse');
@@ -127,16 +109,13 @@ function RunTest()
         $conn->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
         echo "\n";
 
-        // Test a simple select to get output
-        TestSimpleSelect($conn);
-        
         // Test with a simple stored procedure 
         TestReverse($conn);
         
         // Now test with another stored procedure
         $tableName = GetTempTableName();   
         CreateVariantTable($conn, $tableName);
-        
+
         TestOutputParam($conn, $tableName);
         
         $conn = null;
@@ -154,9 +133,6 @@ RunTest();
 ?>
 --EXPECT--
 ﻿
-Number of items: 7
-CD Title: Led Zeppelin 1
-
 SQLSTATE[22018]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Operand type clash: nvarchar(max) is incompatible with sql_variant
 SQLSTATE[22018]: [Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Operand type clash: nvarchar(max) is incompatible with sql_variant
 


### PR DESCRIPTION
split the test pdo_param_output_variants.phpt into two separate tests to get different error messages