### PR TITLE
Fixed load ordering issue in MacOS caused by flat namespace

### DIFF
--- a/source/pdo_sqlsrv/config.m4
+++ b/source/pdo_sqlsrv/config.m4
@@ -66,3 +66,7 @@ if test "$PHP_PDO_SQLSRV" != "no"; then
   PHP_ADD_BUILD_DIR([$ext_builddir/shared], 1)
 fi
 
+#if (defined __APPLE__ && defined __MACH__) \
+  MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion` \
+#endif
+

--- a/source/sqlsrv/config.m4
+++ b/source/sqlsrv/config.m4
@@ -40,3 +40,8 @@ if test "$PHP_SQLSRV" != "no"; then
   PHP_NEW_EXTENSION(sqlsrv, $sqlsrv_src_class $shared_src_class, $ext_shared,,-std=c++11)
   PHP_ADD_BUILD_DIR([$ext_builddir/shared], 1)
 fi
+
+#if (defined __APPLE__ && defined __MACH__) \
+  MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion` \
+#endif
+

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -684,8 +684,6 @@ PHP_FUNCTION( sqlsrv_get_config )
 
 namespace {
 
-// Workaround for name collision problem between the SQLSRV and PDO_SQLSRV drivers on Mac
-// Place get_error_message into the anonymous namespace in util.cpp
 sqlsrv_error_const* get_error_message( unsigned int sqlsrv_error_code ) {
 
 	sqlsrv_error_const *error_message = NULL;


### PR DESCRIPTION
added MACOSX_DEPLOYMENT_TARGET to not use linker flat_namespace flag