### PR TITLE
Modifying UNIX connection pooling tests to not require root permissions

### DIFF
--- a/test/functional/pdo_sqlsrv/PDO_ConnPool_Unix.phpt
+++ b/test/functional/pdo_sqlsrv/PDO_ConnPool_Unix.phpt
@@ -1,7 +1,7 @@
 --TEST--
 PDO_SQLSRV Connection Pooling Test on Unix
 --DESCRIPTION--
-This test assumes the deafult odbcinst.ini has not been modified. 
+This test assumes the default odbcinst.ini has not been modified. 
 --SKIPIF--
 <?php if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') die("Skipped: Test for Linux and Mac"); ?>
 --FILE--

--- a/test/functional/pdo_sqlsrv/PDO_ConnPool_Unix.phpt
+++ b/test/functional/pdo_sqlsrv/PDO_ConnPool_Unix.phpt
@@ -1,63 +1,47 @@
 --TEST--
-PDO Connection Pooling Test on Unix
+PDO_SQLSRV Connection Pooling Test on Unix
 --DESCRIPTION--
-This test assumes odbcinst.ini has not been modified. 
-This test also requires root privileges to modify odbcinst.ini file on Linux.
+This test assumes the deafult odbcinst.ini has not been modified. 
 --SKIPIF--
 <?php if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') die("Skipped: Test for Linux and Mac"); ?>
 --FILE--
 <?php
-// On Bamboo we must use sudo to fiddle with odbcinst.ini
-// On travis-ci we can't use sudo
-$sudo = '';
-$user = posix_getpwuid(posix_geteuid());
-if (strtolower($user['name']) != 'root')
-{
-    $sudo = 'sudo ';
-}
-
 $lines_to_add="CPTimeout=5\n[ODBC]\nPooling=Yes\n";
 
-//get odbcinst.ini location
+//get default odbcinst.ini location
 $lines = explode("\n", shell_exec("odbcinst -j"));
 $odbcinst_ini = explode(" ", $lines[1])[1];
+$custom_odbcinst_ini = dirname(__FILE__)."/odbcinst.ini";
 
-//back up the odbcinst.ini file
-shell_exec($sudo."cp $odbcinst_ini $odbcinst_ini.bak");
+//copy the default odbcinst.ini into the current folder
+copy( $odbcinst_ini, $custom_odbcinst_ini);
 
 //enable pooling by modifying the odbcinst.ini file
-$current = file_get_contents($odbcinst_ini);
+$current = file_get_contents($custom_odbcinst_ini);
 $current.=$lines_to_add;
-shell_exec("cp $odbcinst_ini .");
-file_put_contents("odbcinst.ini", $current);
-shell_exec($sudo."cp odbcinst.ini $odbcinst_ini");
+file_put_contents($custom_odbcinst_ini, $current);
 
 //Creating a new php process, because for changes in odbcinst.ini file to affect pooling, drivers must be reloaded.
-print_r(shell_exec(PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
+//Also setting the odbcini path to the current folder for the same process.
+//This will let us modify odbcinst.ini without root permissions
+print_r(shell_exec("export ODBCSYSINI=".dirname(__FILE__)."&&".PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
+
 
 //disable pooling by modifying the odbcinst.ini file
-$current = file_get_contents($odbcinst_ini);
+$current = file_get_contents($custom_odbcinst_ini);
 $current = str_replace($lines_to_add,'',$current);
-file_put_contents("odbcinst.ini", $current);
-shell_exec($sudo."cp odbcinst.ini $odbcinst_ini");
+file_put_contents($custom_odbcinst_ini, $current);
 
-print_r(shell_exec(PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
+print_r(shell_exec("export ODBCSYSINI=".dirname(__FILE__)."&&".PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
 ?>
 --CLEAN--
 <?php
-$sudo = '';
-$user = posix_getpwuid(posix_geteuid());
-if (strtolower($user['name']) == 'bamboo')
-{
-    $sudo = 'sudo ';
-}
+$custom_odbcinst_ini = dirname(__FILE__)."/odbcinst.ini";
+unlink($custom_odbcinst_ini);
+//back to default odbcinst.ini
+shell_exec("unset ODBCSYSINI");
 
-$lines = explode("\n", shell_exec("odbcinst -j"));
-$odbcinst_ini = explode(" ", $lines[1])[1];
-shell_exec($sudo."cp $odbcinst_ini.bak $odbcinst_ini");
-shell_exec($sudo."rm $odbcinst_ini.bak");
 ?>
 --EXPECT--
 Pooled
 Not Pooled
-

--- a/test/functional/sqlsrv/sqlsrv_ConnPool_Unix.phpt
+++ b/test/functional/sqlsrv/sqlsrv_ConnPool_Unix.phpt
@@ -1,63 +1,47 @@
 --TEST--
 SQLSRV Connection Pooling Test on Unix
 --DESCRIPTION--
-This test assumes odbcinst.ini has not been modified. 
-This test also requires root privileges to modify odbcinst.ini file on Linux.
+This test assumes the deafult odbcinst.ini has not been modified. 
 --SKIPIF--
 <?php if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') die("Skipped: Test for Linux and Mac"); ?>
 --FILE--
 <?php
-// On Bamboo we must use sudo to fiddle with odbcinst.ini
-// On travis-ci we can't use sudo
-$sudo = '';
-$user = posix_getpwuid(posix_geteuid());
-if (strtolower($user['name']) != 'root')
-{
-    $sudo = 'sudo ';
-}
-
 $lines_to_add="CPTimeout=5\n[ODBC]\nPooling=Yes\n";
 
-//get odbcinst.ini location
+//get default odbcinst.ini location
 $lines = explode("\n", shell_exec("odbcinst -j"));
 $odbcinst_ini = explode(" ", $lines[1])[1];
+$custom_odbcinst_ini = dirname(__FILE__)."/odbcinst.ini";
 
-//back up the odbcinst.ini file
-shell_exec($sudo."cp $odbcinst_ini $odbcinst_ini.bak");
+//copy the default odbcinst.ini into the current folder
+copy( $odbcinst_ini, $custom_odbcinst_ini);
 
 //enable pooling by modifying the odbcinst.ini file
-$current = file_get_contents($odbcinst_ini);
+$current = file_get_contents($custom_odbcinst_ini);
 $current.=$lines_to_add;
-shell_exec("cp $odbcinst_ini .");
-file_put_contents("odbcinst.ini", $current);
-shell_exec($sudo."cp odbcinst.ini $odbcinst_ini");
+file_put_contents($custom_odbcinst_ini, $current);
 
 //Creating a new php process, because for changes in odbcinst.ini file to affect pooling, drivers must be reloaded.
-print_r(shell_exec(PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
+//Also setting the odbcini path to the current folder for the same process.
+//This will let us modify odbcinst.ini without root permissions
+print_r(shell_exec("export ODBCSYSINI=".dirname(__FILE__)."&&".PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
+
 
 //disable pooling by modifying the odbcinst.ini file
-$current = file_get_contents($odbcinst_ini);
+$current = file_get_contents($custom_odbcinst_ini);
 $current = str_replace($lines_to_add,'',$current);
-file_put_contents("odbcinst.ini", $current);
-shell_exec($sudo."cp odbcinst.ini $odbcinst_ini");
+file_put_contents($custom_odbcinst_ini, $current);
 
-print_r(shell_exec(PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
+print_r(shell_exec("export ODBCSYSINI=".dirname(__FILE__)."&&".PHP_BINARY." ".dirname(__FILE__)."/isPooled.php"));
 ?>
 --CLEAN--
 <?php
-$sudo = '';
-$user = posix_getpwuid(posix_geteuid());
-if (strtolower($user['name']) == 'bamboo')
-{
-    $sudo = 'sudo ';
-}
+$custom_odbcinst_ini = dirname(__FILE__)."/odbcinst.ini";
+unlink($custom_odbcinst_ini);
+//back to default odbcinst.ini
+shell_exec("unset ODBCSYSINI");
 
-$lines = explode("\n", shell_exec("odbcinst -j"));
-$odbcinst_ini = explode(" ", $lines[1])[1];
-shell_exec($sudo."cp $odbcinst_ini.bak $odbcinst_ini");
-shell_exec($sudo."rm $odbcinst_ini.bak");
 ?>
 --EXPECT--
 Pooled
 Not Pooled
-

--- a/test/functional/sqlsrv/sqlsrv_ConnPool_Unix.phpt
+++ b/test/functional/sqlsrv/sqlsrv_ConnPool_Unix.phpt
@@ -1,7 +1,7 @@
 --TEST--
 SQLSRV Connection Pooling Test on Unix
 --DESCRIPTION--
-This test assumes the deafult odbcinst.ini has not been modified. 
+This test assumes the default odbcinst.ini has not been modified. 
 --SKIPIF--
 <?php if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') die("Skipped: Test for Linux and Mac"); ?>
 --FILE--


### PR DESCRIPTION
Instead of modifying odbcinst.ini in /etc folder, the test now copies odbcinst.ini into the current folder and sets an environment variable to make unixODBC use the custom odbcinst.ini. This way the test does not requiere root permissions to modify that file. 