### PR TITLE
Temporary entity names to ensure uniqueness

### DIFF
--- a/test/functional/sqlsrv/MsCommon.inc
+++ b/test/functional/sqlsrv/MsCommon.inc
@@ -165,7 +165,7 @@ function GetTempTableName($table = '', $temporary = true)
     // dropped once the connection is closed. Otherwise, the caller 
     // should take care of dropping the temp table afterwards.
     
-    $timestamp = round(microtime(true)*1000);
+    $someNumber = rand(0, 1000);
     
     $prefix = '';
     if ($temporary)
@@ -174,7 +174,7 @@ function GetTempTableName($table = '', $temporary = true)
     if (strlen($table) == 0)
         $table = 'php_test_table';
         
-    return $prefix . $table . '_' . $timestamp;
+    return $prefix . $table . '_' . $someNumber;
 }
 
 function GetTempProcName($proc = '', $temporary = true)
@@ -183,7 +183,7 @@ function GetTempProcName($proc = '', $temporary = true)
     // automatically dropped once the connection is closed. Otherwise, 
     // the caller should take care of dropping the temp procedure afterwards.    
     
-    $timestamp = round(microtime(true)*1000);
+    $someNumber = rand(0, 1000);
 
     $prefix = '';
     if ($temporary)
@@ -192,7 +192,7 @@ function GetTempProcName($proc = '', $temporary = true)
     if (strlen($proc) == 0)
         $proc = 'php_test_proc'; 
 
-    return $prefix . $proc . '_' . $timestamp;
+    return $prefix . $proc . '_' . $someNumber;
 }
 
 function ExecuteQuery($conn, $query)

--- a/test/functional/sqlsrv/srv_073_database.phpt
+++ b/test/functional/sqlsrv/srv_073_database.phpt
@@ -12,13 +12,7 @@ if( !$conn ) {
 }
 
 // Set database name
-$dbUniqueName = "php_uniqueDB01";
-
-// DROP database if exists
-$stmt = sqlsrv_query($conn,"IF EXISTS(SELECT name FROM sys.databases WHERE name = '"
-    .$dbUniqueName."') DROP DATABASE ".$dbUniqueName);
-if($stmt === false){ die( print_r( sqlsrv_errors(), true )); }
-sqlsrv_free_stmt($stmt);
+$dbUniqueName = "php_uniqueDB_" . rand(0, 1000);
 
 // CREATE database
 $stmt = sqlsrv_query($conn,"CREATE DATABASE ". $dbUniqueName);


### PR DESCRIPTION
Use random number generator instead of microtime() because it fails occasionally, which generates incorrect timestamps