### PR TITLE
Whilst installing on MacOS, I noticed that the install commands for the pecl dependencies use sudo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,20 @@ The following instructions assume a clean environment and show how to install PH
 
 ### Step 3: Install the Microsoft PHP Drivers for SQL Server
 
-*Note: The first step is not required in Mac OS X. PECL installs the stable version when version is not specified. You may run `sudo pecl search sqlsrv` to search for the latest releases and `sudo pecl install sqlsrv-[version]` to install a specific version. Drivers are Mac-compatible starting from `4.1.7preview` release.
+**Ubuntu / RedHat**
+
+*Note: PECL installs the stable version when version is not specified. You may run `sudo pecl search sqlsrv` to search for the latest releases and `sudo pecl install sqlsrv-[version]` to install a specific version.
 
     sudo pear config-set php_ini `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"` system
     sudo pecl install sqlsrv
     sudo pecl install pdo_sqlsrv
+
+**Mac OS X**
+
+*Note: PECL installs the stable version when version is not specified. You may run `pecl search sqlsrv` to search for the latest releases and `pecl install sqlsrv-[version]` to install a specific version. Drivers are Mac-compatible starting from `4.1.7preview` release.
+
+    pecl install sqlsrv
+    pecl install pdo_sqlsrv
    
 ### Step 4: Install and Configure Apache
 


### PR DESCRIPTION
The Homebrew project recommend against using sudo for build tools, and since pecl was installed by Homebrew, this fits into the same category.

See https://github.com/Homebrew/brew/blob/master/docs/FAQ.md#why-does-homebrew-say-sudo-is-bad for further info.