### PR TITLE
Update README.md on Install Prerequisites for installing msodbcsql which should run not run in homebrew sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The following instructions assume a clean environment and show how to install PH
 
 	brew tap microsoft/msodbcsql https://github.com/Microsoft/homebrew-mssql-release
 	brew update
-	brew install msodbcsql
+	brew install --no-sandbox msodbcsql
 	brew install mssql-tools
 	brew install autoconf
 


### PR DESCRIPTION
I have determined that the install failure is due to another "security feature" recently introduced into Homebrew --- as of 1.3.0 --- which runs all installers in a restricted sandbox environment: Homebrew/brew#2898

However, you can still disable that with an option, and it will register the driver in odbcinst.ini correctly without having to perform the manual workaround above:

https://github.com/Microsoft/homebrew-mssql-release/issues/1#issuecomment-319729335