### PR TITLE
Fixed test issue with PHP 7.2

### DIFF
--- a/test/functional/sqlsrv/sqlsrv_empty_result_error.phpt
+++ b/test/functional/sqlsrv/sqlsrv_empty_result_error.phpt
@@ -36,7 +36,7 @@ function CheckError($expectedErrors)
         $sizeActualErrors = sizeof($actualErrors);
     }
 
-    if ($sizeActualErrors) != sizeof($expectedErrors)) {
+    if (($sizeActualErrors) != sizeof($expectedErrors)) {
         echo "Wrong size for error array\n";
         print_r($actualErrors);
         return;

--- a/test/functional/sqlsrv/sqlsrv_empty_result_error.phpt
+++ b/test/functional/sqlsrv/sqlsrv_empty_result_error.phpt
@@ -31,8 +31,12 @@ $errorFuncSeq = 'getFuncSeqError';
 function CheckError($expectedErrors)
 {
     $actualErrors = sqlsrv_errors();
+    $sizeActualErrors = 0;
+    if (!is_null($actualErrors)) {
+        $sizeActualErrors = sizeof($actualErrors);
+    }
 
-    if (sizeof($actualErrors) != sizeof($expectedErrors)) {
+    if ($sizeActualErrors) != sizeof($expectedErrors)) {
         echo "Wrong size for error array\n";
         print_r($actualErrors);
         return;


### PR DESCRIPTION
Modified sqlsrv_empty_result_error.phpt to not trigger a complaint about sizeof() not working with nulls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/600)
<!-- Reviewable:end -->
