### PR TITLE
Fix PDO67_BindTruncation test

### DIFF
--- a/test/functional/pdo_sqlsrv/PDO67_BindTruncation.phpt
+++ b/test/functional/pdo_sqlsrv/PDO67_BindTruncation.phpt
@@ -15,19 +15,16 @@ try {
 
     // Prepare test table
     $tableName = "pdo_test_table";
-    createTable($conn1, $tableName, array(new ColumnMeta("int", "id", "IDENTITY NOT NULL"), "class" => "int", "value" => "char(32)"));
+    createTable($conn1, $tableName, array("id" => "int", "class" => "int", "value" => "char(32)"));
     $conn1->exec("CREATE CLUSTERED INDEX [idx_test_int] ON $tableName (id)");
-    $tsql1 = "SET IDENTITY_INSERT [$tableName] ON";
-    $tsql2 = "INSERT INTO [$tableName] (id, class, value) VALUES(:id, :class, :value)";
-    $tsql3 = "SET IDENTITY_INSERT [$tableName] OFF";
-    $tsql4 = "SELECT id, value FROM [$tableName]";
+    $tsql = "INSERT INTO [$tableName] (id, class, value) VALUES(:id, :class, :value)";
 
     $id = 0;
     $class = 0;
     $value = '';
 
     // Prepare insert query$
-    $stmt1 = $conn1->prepare("$tsql1; $tsql2; $tsql3;");
+    $stmt1 = $conn1->prepare($tsql);
     bindParam(1, $stmt1, ':id', $id);
     bindParam(2, $stmt1, ':class', $class);
     bindParam(3, $stmt1, ':value', $value);
@@ -53,7 +50,8 @@ try {
     // Check data
     $id = 0;
     $value = '';
-    $stmt2 = $conn1->query($tsql4);
+    $tsql = "SELECT id, value FROM [$tableName]";
+    $stmt2 = $conn1->query($tsql);
     bindColumn(1, $stmt2, $id, $value);
     while ($stmt2->fetch(PDO::FETCH_BOUND)) {
         printf(
@@ -77,29 +75,29 @@ try {
 function bindParam($offset, $stmt, $param, &$value)
 {
     if (!$stmt->bindParam($param, $value)) {
-        LogInfo($offset, "Cannot bind parameter $param");
+        logInfo($offset, "Cannot bind parameter $param");
     }
 }
 
 function bindColumn($offset, $stmt, &$param1, &$param2)
 {
     if (!$stmt->bindColumn(1, $param1, PDO::PARAM_INT)) {
-        LogInfo($offset, "Cannot bind integer column");
+        logInfo($offset, "Cannot bind integer column");
     }
     if (!$stmt->bindColumn(2, $param2, PDO::PARAM_STR)) {
-        LogInfo($offset, "Cannot bind string column");
+        logInfo($offset, "Cannot bind string column");
     }
 }
 
 function execStmt($offset, $stmt)
 {
     if (!$stmt->execute()) {
-        LogInfo($offset, "Cannot execute statement");
+        logInfo($offset, "Cannot execute statement");
         var_dump($stmt->errorInfo());
     }
 }
 
-function LogInfo($offset, $msg)
+function logInfo($offset, $msg)
 {
     printf("[%03d] %s\n", $offset, $msg);
 }


### PR DESCRIPTION
Doing `"SET IDENTITY_INSERT [$tableName] ON` or `OFF` with prepared statements has no effect. Only works with direct queries.
Reason:  A prepared statement runs in a separate context.
For more info, please click [here](https://social.msdn.microsoft.com/Forums/sqlserver/en-US/b6d41dfc-ad83-4ed2-88be-6573baa040de/dynamically-set-identityinsert-onoff-in-stored-procedure?forum=transactsql)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/629)
<!-- Reviewable:end -->
