### PR TITLE
Removeresetcursor

### DIFF
--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -83,7 +83,7 @@ bool get_bit( _In_ void* ptr, _In_ unsigned int bit )
 
 // read in LOB field during buffered result creation
 SQLPOINTER read_lob_field( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_index, _In_ sqlsrv_buffered_result_set::meta_data& meta,
-                           _In_ zend_long mem_used, _In_ size_t row_count TSRMLS_DC );
+                           _In_ zend_long mem_used TSRMLS_DC );
 
 // dtor for each row in the cache
 void cache_row_dtor( _In_ zval* data );
@@ -687,7 +687,7 @@ sqlsrv_buffered_result_set::sqlsrv_buffered_result_set( _Inout_ sqlsrv_stmt* stm
 
                             out_buffer_length = &out_buffer_temp;
                             SQLPOINTER* lob_addr = reinterpret_cast<SQLPOINTER*>( &row[ meta[i].offset ] );
-                            *lob_addr = read_lob_field( stmt, i, meta[i], mem_used, row_count TSRMLS_CC );
+                            *lob_addr = read_lob_field( stmt, i, meta[i], mem_used TSRMLS_CC );
                             // a NULL pointer means NULL field
                             if( *lob_addr == NULL ) {
                                 *out_buffer_length = SQL_NULL_DATA;
@@ -1498,7 +1498,7 @@ void cache_row_dtor( _In_ zval* data )
 }
 
 SQLPOINTER read_lob_field( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_index, _In_ sqlsrv_buffered_result_set::meta_data& meta, 
-                           _In_ zend_long mem_used, _In_ size_t row_count TSRMLS_DC )
+                           _In_ zend_long mem_used TSRMLS_DC )
 {
     SQLSMALLINT extra = 0;
     SQLULEN* output_buffer_len = NULL;
@@ -1563,19 +1563,7 @@ SQLPOINTER read_lob_field( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_in
 
         SQLSRV_ASSERT( SQL_SUCCEEDED( r ), "Unknown SQL error not triggered" );
 
-        if ( stmt->conn->ce_option.enabled == true ) {
-            // cursor type SQLSRV_CURSOR_BUFFERED has to be FORWARD_ONLY
-            // thus has to close and reopen cursor to reset the cursor buffer
-            core::SQLCloseCursor(stmt);
-            core::SQLExecute(stmt);
-            // FETCH_NEXT until the cursor reaches the row that it was at
-            for (int i = 0; i <= row_count; i++) {
-                core::SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0);
-            }
-        }
-        else {
-            already_read += to_read - already_read;
-        }
+        already_read += to_read - already_read;
         // if the type of the field returns the total to be read, we use that and preallocate the buffer
         if( last_field_len != SQL_NO_TOTAL ) {
 

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -1380,8 +1380,6 @@ struct sqlsrv_stmt : public sqlsrv_context {
     bool past_fetch_end;                  // Core_sqlsrv_fetch sets this field when the statement goes beyond the last row
     sqlsrv_result_set* current_results;   // Current result set
     SQLULEN cursor_type;                  // Type of cursor for the current result set
-    int fwd_row_index;                    // fwd_row_index is the current row index, SQL_CURSOR_FORWARD_ONLY
-    int curr_result_set;                  // the current active result set, 0 by default but will be incremented by core_sqlsrv_next_result
     bool has_rows;                        // Has_rows is set if there are actual rows in the row set
     bool fetch_called;                    // Used by core_sqlsrv_get_field to return an informative error if fetch not yet called 
     int last_field_index;                 // last field retrieved by core_sqlsrv_get_field

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -2303,8 +2303,7 @@ void get_field_as_string( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_ind
 
                             // Get the rest of the data.
                             r = stmt->current_results->get_data( field_index + 1, c_type, field_value_temp + initial_field_len,
-                                field_len_temp + extra, &dummy_field_len,
-                                false /*handle_warning*/ TSRMLS_CC );
+                                field_len_temp + extra, &dummy_field_len, false /*handle_warning*/ TSRMLS_CC );
                             // the last packet will contain the actual amount retrieved, not SQL_NO_TOTAL
                             // so we calculate the actual length of the string with that.
                             if ( dummy_field_len != SQL_NO_TOTAL )
@@ -2329,8 +2328,7 @@ void get_field_as_string( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_ind
 
                         // Get the rest of the data.
                         r = stmt->current_results->get_data( field_index + 1, c_type, field_value_temp + intial_field_len,
-                            field_len_temp + extra, &dummy_field_len,
-                            true /*handle_warning*/ TSRMLS_CC );
+                            field_len_temp + extra, &dummy_field_len, true /*handle_warning*/ TSRMLS_CC );
                         field_len_temp += intial_field_len;
 
                         if( dummy_field_len == SQL_NULL_DATA ) {

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -2323,7 +2323,7 @@ void get_field_as_string( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_ind
                         // allocate field_len_temp (which is the field length retrieved from the first SQLGetData
                         field_value_temp = static_cast<char*>( sqlsrv_realloc( field_value_temp, field_len_temp + extra + 1 ));
 
-                        // We have already recieved intial_field_len size data.
+                        // We have already received intial_field_len size data.
                         field_len_temp -= intial_field_len;
 
                         // Get the rest of the data.
@@ -2592,8 +2592,8 @@ void resize_output_buffer_if_necessary( _Inout_ sqlsrv_stmt* stmt, _Inout_ zval*
 }
 
 void adjustInputPrecision( _Inout_ zval* param_z, _In_ SQLSMALLINT decimal_digits ) {
+    // 38 is the maximum length of a stringified decimal number
     size_t maxDecimalPrecision = 38;
-    // maxDecimalStrLen is the maximum length of a stringified decimal number
     // 6 is derived from: 1 for '.'; 1 for sign of the number; 1 for 'e' or 'E' (scientific notation);
     //                    1 for sign of scientific exponent; 2 for length of scientific exponent
     // if the length is greater than maxDecimalStrLen, do not change the string

--- a/test/functional/sqlsrv/0020.phpt
+++ b/test/functional/sqlsrv/0020.phpt
@@ -23,8 +23,6 @@ function runTest($fieldType)
     sqlsrv_fetch($stmt)
         || die(print_r(sqlsrv_errors(), true));
 
-    // Do not support getting stream if AE enabled, so expect 
-    // it to fail with the correct error message
     $stream = sqlsrv_get_field($stmt, 0, SQLSRV_PHPTYPE_STREAM("char"));
     if ($stream) {
         stream_filter_append($originalStream, "convert.base64-encode")
@@ -37,11 +35,7 @@ function runTest($fieldType)
             }
         }
     } else {
-        if (AE\isColEncrypted()) {
-            verifyError(sqlsrv_errors()[0], 'IMSSP', 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.');
-        } else {
-            fatalError('Fetching data stream failed!');
-        }
+        fatalError('Fetching data stream failed!');
     }
     dropTable($conn, $params['tableName']);
     

--- a/test/functional/sqlsrv/0066.phpt
+++ b/test/functional/sqlsrv/0066.phpt
@@ -38,11 +38,7 @@ inserting and retrieving UTF-8 text.
 
     $u = sqlsrv_get_field($s, 1, SQLSRV_PHPTYPE_STREAM('utf-8'));
     if ($u === false) {
-        if (AE\isColEncrypted()) {
-            verifyError(sqlsrv_errors()[0], 'IMSSP', 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.');
-        } else {
-            die(print_r(sqlsrv_errors(), true));
-        }
+        die(print_r(sqlsrv_errors(), true));
     } else {
         $utf8_2 = fread($u, 10000);
         if ($utf8 != $utf8_2) {

--- a/test/functional/sqlsrv/TC42_FetchField.phpt
+++ b/test/functional/sqlsrv/TC42_FetchField.phpt
@@ -33,9 +33,6 @@ function fetchFields()
     $stmt1 = AE\selectFromTable($conn1, $tableName);
     $numFields = sqlsrv_num_fields($stmt1);
 
-    $errState = 'IMSSP';
-    $errMessage = 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.';
-    
     trace("Retrieving $noRowsInserted rows with $numFields fields each ...");
     for ($i = 0; $i < $noRowsInserted; $i++) {
         $row = sqlsrv_fetch($stmt1);
@@ -44,16 +41,9 @@ function fetchFields()
         }
         for ($j = 0; $j < $numFields; $j++) {
             $fld = sqlsrv_get_field($stmt1, $j);
-            
-            // With AE enabled, those fields that sqlsrv_get_field() will fetch
-            // as stream data will return a specific error message
             $col = $j+1;
             if ($fld === false) {
-                if (AE\isColEncrypted() && isStreamData($col)) {
-                    verifyError(sqlsrv_errors()[0], $errState, $errMessage);
-                } else {
-                    fatalError("Field $j of Row $i is missing\n", true);
-                }
+                fatalError("Field $j of Row $i is missing\n", true);
             }
         }
     }

--- a/test/functional/sqlsrv/TC51_StreamRead.phpt
+++ b/test/functional/sqlsrv/TC51_StreamRead.phpt
@@ -68,7 +68,7 @@ function verifyStream($stmt, $row, $colIndex)
             }
         }
         if ($stream === false) {
-            verifyStreamError("Failed to read field $col: $type");
+            fatalError("Failed to read field $col: $type");
         } else {
             $value = '';
             if ($stream) {
@@ -84,16 +84,6 @@ function verifyStream($stmt, $row, $colIndex)
             }
             traceData($type, "".strlen($value)." bytes");
         }
-    }
-}
-
-function verifyStreamError($message)
-{
-    global $errState, $errMessage;
-    if (AE\isColEncrypted()) {
-        verifyError(sqlsrv_errors()[0], $errState, $errMessage);
-    } else {
-        fatalError($message);
     }
 }
 
@@ -127,10 +117,6 @@ function checkData($col, $actual, $expected)
 setUSAnsiLocale();
 global $testName;
 $testName = "Stream - Read";
-
-// error message expected with AE enabled
-$errState = 'IMSSP';
-$errMessage = 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.';
 
 // test ansi only if windows or non-UTF8 locales are supported (ODBC 17 and above)
 startTest($testName);

--- a/test/functional/sqlsrv/TC81_MemoryCheck.phpt
+++ b/test/functional/sqlsrv/TC81_MemoryCheck.phpt
@@ -272,9 +272,6 @@ function runTest($noPasses, $noRows, $tableName, $conn, $prepared, $release, $mo
                 break;
 
             case 5:    // fetch fields
-                $errState = 'IMSSP';
-                $errMessage = 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.';
-
                 $stmt = execQuery($conn, $tableName, $prepared);
                 $numFields = sqlsrv_num_fields($stmt);
                 while (sqlsrv_fetch($stmt)) {
@@ -284,11 +281,7 @@ function runTest($noPasses, $noRows, $tableName, $conn, $prepared, $release, $mo
                         $col = $i + 1;
 
                         if ($fld === false) {
-                            if (AE\isColEncrypted() && isStreamData($col)) {
-                                verifyError(sqlsrv_errors()[0], $errState, $errMessage);
-                            } else {
-                                fatalError("Field $i of row $rowCount is missing");
-                            }
+                            fatalError("Field $i of row $rowCount is missing");
                         }
                         unset($fld);
                     }

--- a/test/functional/sqlsrv/sqlsrv_fetch_large_stream.phpt
+++ b/test/functional/sqlsrv/sqlsrv_fetch_large_stream.phpt
@@ -35,23 +35,15 @@ if (!sqlsrv_fetch($stmt)) {
 $stream = sqlsrv_get_field($stmt, 0, SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_CHAR));
 
 $success = false;
-if ($stream === false) {
-    $error = sqlsrv_errors()[0];
-    if (AE\isColEncrypted() && $error['SQLSTATE'] === "IMSSP" && $error['code'] === -109 &&
-        $error['message'] === "Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.") {
-        $success = true;
-    }
-} else {
+if ($stream !== false) {
     $value = '';
-    if (!AE\isColEncrypted()) {
-        $num = 0;
-        while (!feof($stream)) {
-            $value .= fread($stream, 8192);
-        }
-        fclose($stream);
-        if (checkData($value, $inValue)) {  // compare the data to see if they match!
-            $success = true;
-        }
+    $num = 0;
+    while (!feof($stream)) {
+        $value .= fread($stream, 8192);
+    }
+    fclose($stream);
+    if (checkData($value, $inValue)) {  // compare the data to see if they match!
+        $success = true;
     }
 }
 if ($success) {

--- a/test/functional/sqlsrv/sqlsrv_prepare.phpt
+++ b/test/functional/sqlsrv/sqlsrv_prepare.phpt
@@ -80,11 +80,7 @@ binding parameters, including output parameters, using the simplified syntax.
         echo "$name\n";
         $stream = sqlsrv_get_field($stmt, 3, SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY));
         if (!$stream) {
-            if (AE\isColEncrypted()) {
-                verifyError(sqlsrv_errors()[0], 'IMSSP', 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.');
-            } else {
-                fatalError('Fetching data stream failed!');
-            }
+            fatalError('Fetching data stream failed!');
         } else {
             while (!feof($stream)) {
                 $str = fread($stream, 10000);

--- a/test/functional/sqlsrv/sqlsrv_query.phpt
+++ b/test/functional/sqlsrv/sqlsrv_query.phpt
@@ -49,11 +49,7 @@ sqlsrv_query test. Performs same tasks as 0006.phpt, using sqlsrv_query.
         echo "$name\n";
         $stream = sqlsrv_get_field($stmt, 3, SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY));
         if (!$stream) {
-            if (AE\isColEncrypted()) {
-                verifyError(sqlsrv_errors()[0], 'IMSSP', 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.');
-            } else {
-                fatalError('Fetching data stream failed!');
-            }
+            fatalError('Fetching data stream failed!');
         } else {
             while (!feof($stream)) {
                 $str = fread($stream, 4000);

--- a/test/functional/sqlsrv/sqlsrv_send_stream_data.phpt
+++ b/test/functional/sqlsrv/sqlsrv_send_stream_data.phpt
@@ -114,11 +114,7 @@ binding streams using full syntax.
         echo "$name\n";
         $stream = sqlsrv_get_field($stmt, 3, SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY));
         if (!$stream) {
-            if (AE\isColEncrypted()) {
-                verifyError(sqlsrv_errors()[0], 'IMSSP', 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.');
-            } else {
-                fatalError('Fetching data stream failed!');
-            }
+            fatalError('Fetching data stream failed!');
         } else {
             while (!feof($stream)) {
                 $str = fread($stream, 10000);

--- a/test/functional/sqlsrv/test_warning_errors3.phpt
+++ b/test/functional/sqlsrv/test_warning_errors3.phpt
@@ -86,11 +86,7 @@ error messages when trying to retrieve past the end of a result set and when no 
         echo "$name\n";
         $stream = sqlsrv_get_field($stmt, 3, SQLSRV_PHPTYPE_STREAM(SQLSRV_ENC_BINARY));
         if (!$stream) {
-            if (AE\isColEncrypted()) {
-                verifyError(sqlsrv_errors()[0], 'IMSSP', 'Connection with Column Encryption enabled does not support fetching stream. Please fetch the data as a string.');
-            } else {
-                fatalError('Fetching data stream failed!');
-            }
+            fatalError('Fetching data stream failed!');
         } else {
             while (!feof($stream)) {
                 $str = fread($stream, 10000);


### PR DESCRIPTION
Remove workaround for reseting the cursor when fetching streams with Always Encrypted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/662)
<!-- Reviewable:end -->
