### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Note that [Microsoft ODBC Driver 17][odbc17] is required for Ubuntu 17 and Debia
     curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
     exit
     sudo apt-get update
-    sudo ACCEPT_EULA=Y apt-get install msodbcsql mssql-tools 
+    sudo ACCEPT_EULA=Y apt-get install msodbcsql=13.1.4.0-1 mssql-tools=14.0.3.0-1 unixodbc-dev 
     sudo apt-get install unixodbc-dev
     echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
     echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc


### PR DESCRIPTION
update to sudo ACCEPT_EULA=Y apt-get install msodbcsql=13.1.4.0-1 mssql-tools=14.0.3.0-1 unixodbc-dev

lets be specific with the version of Microsoft's ODBS & tool, i found out it's failing to work for Ubuntu 16.04 (both PHP 7.0 & PHP 7.1) to failed since a new version of msodbcsql has been released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/688)
<!-- Reviewable:end -->
