### PR TITLE
Fixed output to test

### DIFF
--- a/test/functional/pdo_sqlsrv/pdo_utf8_conn.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_utf8_conn.phpt
@@ -21,7 +21,7 @@ if ($c !== false) {
 ?>
 --EXPECTREGEX--
 
-Fatal error: Uncaught PDOException: SQLSTATE\[(28000|08001|HYT00)\]: .*\[Microsoft\]\[ODBC Driver 1[0-9] for SQL Server\](\[SQL Server\])?(Named Pipes Provider: Could not open a connection to SQL Server \[2\]\. |Login timeout expired|Login failed for user 'sa'\.) in .+(\/|\\)pdo_utf8_conn\.php:[0-9]+
+Fatal error: Uncaught PDOException: SQLSTATE\[(28000|08001|HYT00)\]: .*\[Microsoft\]\[ODBC Driver 1[0-9] for SQL Server\](\[SQL Server\])?(Named Pipes Provider: Could not open a connection to SQL Server \[2\]\. |TCP Provider: Error code 0x2AF9|Login timeout expired|Login failed for user 'sa'\.) in .+(\/|\\)pdo_utf8_conn\.php:[0-9]+
 Stack trace:
 #0 .+(\/|\\)pdo_utf8_conn\.php\([0-9]+\): PDO->__construct\('sqlsrv:Server=l\.\.\.', 'sa', 'Sunshine4u'\)
 #1 {main}


### PR DESCRIPTION
ODBC Driver 17.1 seems to change the output slightly on mac when connection attempt fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/737)
<!-- Reviewable:end -->
