### PR TITLE
Use SQLSRV_ASSERT for checking NULL ptrs

### DIFF
--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -345,7 +345,8 @@ sqlsrv_error* odbc_get_diag_rec( _In_ sqlsrv_stmt* odbc, _In_ SQLSMALLINT record
     SQLWCHAR wnative_message[ SQL_MAX_ERROR_MESSAGE_LENGTH + 1 ];
     SQLINTEGER native_code;
     SQLSMALLINT wnative_message_len = 0;
-
+    
+    SQLSRV_ASSERT(odbc != NULL, "odbc_get_diag_rec: sqlsrv_stmt* odbc was null.");
     SQLRETURN r = SQLGetDiagRecW( SQL_HANDLE_STMT, odbc->handle(), record_number, wsql_state, &native_code, wnative_message, 
                                   SQL_MAX_ERROR_MESSAGE_LENGTH + 1, &wnative_message_len );
     if( !SQL_SUCCEEDED( r ) || r == SQL_NO_DATA ) {

--- a/source/shared/core_stream.cpp
+++ b/source/shared/core_stream.cpp
@@ -26,7 +26,7 @@ namespace {
 int sqlsrv_stream_close( _Inout_ php_stream* stream, int /*close_handle*/ TSRMLS_DC )
 {
     sqlsrv_stream* ss = static_cast<sqlsrv_stream*>( stream->abstract );
-    SQLSRV_ASSERT( ss != NULL, "sqlsrv_stream_close: sqlsrv_stream* ss was null." );
+    SQLSRV_ASSERT( ss != NULL && ss->stmt != NULL, "sqlsrv_stream_close: sqlsrv_stream* ss was null." );
     
     // free the stream resources in the Zend engine
     php_stream_free( stream, PHP_STREAM_FREE_RELEASE_STREAM );
@@ -52,7 +52,7 @@ size_t sqlsrv_stream_read( _Inout_ php_stream* stream, _Out_writes_bytes_(count)
     sqlsrv_malloc_auto_ptr<char> temp_buf;
 
     sqlsrv_stream* ss = static_cast<sqlsrv_stream*>( stream->abstract );
-    SQLSRV_ASSERT( ss != NULL, "sqlsrv_stream_read: sqlsrv_stream* ss is NULL." );
+    SQLSRV_ASSERT( ss != NULL && ss->stmt != NULL, "sqlsrv_stream_read: sqlsrv_stream* ss is NULL." );
 
     try {
 


### PR DESCRIPTION
Use SQLSRV_ASSERT to ensure the subsequent code will not dereference any null pointers (Clang Analyzer reports)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/789)
<!-- Reviewable:end -->
