### PR TITLE
Fix for PHP 7.3

### DIFF
--- a/source/pdo_sqlsrv/pdo_util.cpp
+++ b/source/pdo_sqlsrv/pdo_util.cpp
@@ -512,7 +512,7 @@ bool pdo_sqlsrv_handle_dbh_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned
                 msg = static_cast<char*>( sqlsrv_malloc( msg_len ) );
                 core_sqlsrv_format_message( msg, static_cast<unsigned int>( msg_len ), WARNING_TEMPLATE, error->sqlstate, error->native_code,
                                             error->native_message );
-                php_error( E_WARNING, msg );
+                php_error( E_WARNING, "%s", msg );
             }
             ctx.set_last_error( error );
             break;

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -2381,10 +2381,7 @@ namespace core {
 
     inline void sqlsrv_array_init( _Inout_ sqlsrv_context& ctx, _Out_ zval* new_array TSRMLS_DC) 
     {
-        int zr = ::array_init(new_array);
-        CHECK_ZEND_ERROR( zr, ctx, SQLSRV_ERROR_ZEND_HASH ) {
-            throw CoreException();
-        }
+        array_init(new_array);
     }
 
     inline void sqlsrv_php_stream_from_zval_no_verify( _Inout_ sqlsrv_context& ctx, _Outref_result_maybenull_ php_stream*& stream, _In_opt_ zval* stream_z TSRMLS_DC )

--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -353,10 +353,10 @@ void die( _In_opt_ const char* msg, ... )
     DWORD rc = FormatMessage( FORMAT_MESSAGE_FROM_STRING, msg, 0, 0, last_err_msg, sizeof( last_err_msg ), &format_args );
     va_end( format_args );
     if( rc == 0 ) {
-        php_error( E_ERROR, reinterpret_cast<const char*>( INTERNAL_FORMAT_ERROR ));
+        php_error( E_ERROR, "%s", reinterpret_cast<const char*>( INTERNAL_FORMAT_ERROR ));
     }
 
-    php_error( E_ERROR, last_err_msg );
+    php_error( E_ERROR, "%s", last_err_msg );
 }
 
 namespace {

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -889,7 +889,9 @@ PHP_FUNCTION( sqlsrv_fetch_object )
             fci.object = Z_OBJ_P( &retval_z );
 
             memset( &fcic, 0, sizeof( fcic ));
+#if PHP_VERSION_ID < 70300
             fcic.initialized = 1;
+#endif
             fcic.function_handler = class_entry->constructor;
             fcic.calling_scope = class_entry;
 
@@ -1806,10 +1808,8 @@ void fetch_fields_common( _Inout_ ss_sqlsrv_stmt* stmt, _In_ zend_long fetch_typ
         field_names.transferred();
     }
 
-    int zr = array_init( &fields );
-	CHECK_ZEND_ERROR( zr, stmt, SQLSRV_ERROR_ZEND_HASH ) {
-		throw ss::SSException();
-	}
+    int zr;
+    array_init( &fields );
 
 	for( int i = 0; i < num_cols; ++i ) {
 		SQLLEN field_len = -1;

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -506,10 +506,7 @@ PHP_FUNCTION( sqlsrv_errors )
 	int result;
 	zval err_z;
 	ZVAL_UNDEF( &err_z );
-	result = array_init( &err_z );
-	if( result == FAILURE ) {
-		RETURN_FALSE;
-	}
+	array_init( &err_z );
 	if( flags == SQLSRV_ERR_ALL || flags == SQLSRV_ERR_ERRORS ) {
 		if( Z_TYPE( SQLSRV_G( errors )) == IS_ARRAY && !sqlsrv_merge_zend_hash( &err_z, &SQLSRV_G( errors ) TSRMLS_CC )) {
 			zval_ptr_dtor(&err_z);
@@ -747,9 +744,7 @@ void copy_error_to_zval( _Inout_ zval* error_z, _In_ sqlsrv_error_const* error, 
                          _In_ bool warning TSRMLS_DC )
 {
 
-    if( array_init( error_z ) == FAILURE ) {
-        DIE( "Fatal error during error processing" );
-    }
+    array_init( error_z );
 
     // sqlstate
     zval temp; 
@@ -837,10 +832,7 @@ bool handle_errors_and_warnings( _Inout_ sqlsrv_context& ctx, _Inout_ zval* repo
     if( Z_TYPE_P( reported_chain ) == IS_NULL ) {
 
         reported_chain_was_null = true;
-        zr = array_init( reported_chain );
-        if( zr == FAILURE ) {
-            DIE( "Fatal error in handle_errors_and_warnings" );
-        }
+        array_init( reported_chain );
     }
     else {
         prev_reported_cnt = zend_hash_num_elements( Z_ARRVAL_P( reported_chain ));
@@ -852,10 +844,7 @@ bool handle_errors_and_warnings( _Inout_ sqlsrv_context& ctx, _Inout_ zval* repo
         if( Z_TYPE_P( ignored_chain ) == IS_NULL ) {
             
            ignored_chain_was_null = true;
-           zr = array_init( ignored_chain );
-            if( zr == FAILURE ) {
-                DIE( "Fatal error in handle_errors_and_warnings" );
-            }
+           array_init( ignored_chain );
         }
     }
 


### PR DESCRIPTION
About **1st commit**, from UPGRADING.INTERNALS

```
  a. array_init() and array_init_size() are not functions anymore.
     They don't return any values.

```

About **2nd commit**, -Wformat warning are strangely not raised in PHP < 7.3, but point to real issue. The commit only fix the [-Werror=format-security] with break builds with hardened build options.

About **3rd commit**, from UPGRADING.INTERNALS

```
  k. zend_fcall_info_cache.initialized is removed. zend_fcall_info_cache is
     initialized if zend_fcall_info_cache.function_handler is set.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/810)
<!-- Reviewable:end -->
