### PR TITLE
Fix for compilation problem

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -463,7 +463,8 @@ struct pdo_dbh_methods pdo_sqlsrv_dbh_methods = {
     pdo_sqlsrv_dbh* driver_dbh = reinterpret_cast<pdo_sqlsrv_dbh*>( dbh->driver_data ); \
     driver_dbh->set_func( __FUNCTION__ ); \
     int length = strlen( __FUNCTION__ ) + strlen( ": entering" ); \
-    char func[length+1] = {'\0'}; \
+    char func[length+1]; \
+    memset(func, '\0', length+1); \
     strcpy_s( func, sizeof( __FUNCTION__ ), __FUNCTION__ ); \
     strcat_s( func, length+1, ": entering" ); \
     LOG( SEV_NOTICE, func ); \


### PR DESCRIPTION
Fix for compilation error `error: variable-sized object ?func? may not be initialized | char func[length+1] = {'\0'}; \`



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/826)
<!-- Reviewable:end -->
