### PR TITLE
Added driver to the skipif conditions

### DIFF
--- a/test/functional/pdo_sqlsrv/skipif_version_less_than_2k14.inc
+++ b/test/functional/pdo_sqlsrv/skipif_version_less_than_2k14.inc
@@ -7,13 +7,13 @@ if (!extension_loaded("pdo_sqlsrv")) {
     die("skip Extension not loaded");
 }
 
-$is_win = ( strtoupper( substr( php_uname( 's' ),0,3 ) ) === 'WIN' );
+$is_win = (strtoupper(substr(php_uname('s'),0,3)) === 'WIN');
 
-require_once( "MsSetup.inc" );
+require_once("MsSetup.inc");
 
-$conn = new PDO( "sqlsrv:server = $server ;", $uid, $pwd );
+$conn = new PDO("sqlsrv:server = $server; driver=$driver;", $uid, $pwd);
 if ($conn === false) {
-    die( "skip Could not connect during SKIPIF." );
+    die("skip Could not connect during SKIPIF.");
 }
 
 $msodbcsql_ver = $conn->getAttribute(PDO::ATTR_CLIENT_VERSION)["DriverVer"];
@@ -33,11 +33,11 @@ if (!$is_win) {
 // Get SQL Server Version
 // Exclude this check if running on Azure
 if (!$daasMode) {
-    $stmt = $conn->query( "SELECT @@VERSION" );
+    $stmt = $conn->query("SELECT @@VERSION");
     if ($stmt) {
         $ver_string = $stmt->fetch(PDO::FETCH_NUM)[0];
     } else {
-        die( "skip Could not fetch SQL Server version during SKIPIF.");
+        die("skip Could not fetch SQL Server version during SKIPIF.");
     }
 
     $version = explode(' ', $ver_string);

--- a/test/functional/sqlsrv/skipif_version_less_than_2k14.inc
+++ b/test/functional/sqlsrv/skipif_version_less_than_2k14.inc
@@ -7,15 +7,15 @@ if (!extension_loaded("sqlsrv")) {
     die("skip Extension not loaded");
 }
 
-$is_win = ( strtoupper( substr( php_uname( 's' ),0,3 ) ) === 'WIN' );
+$is_win = (strtoupper(substr(php_uname('s'),0,3)) === 'WIN');
 
-require_once( "MsSetup.inc" );
+require_once("MsSetup.inc");
 
-$connectionInfo = array( "UID"=>$userName, "PWD"=>$userPassword );
+$connectionInfo = array("UID"=>$userName, "PWD"=>$userPassword, "Driver" => $driver);
 
-$conn = sqlsrv_connect( $server, $connectionInfo );
+$conn = sqlsrv_connect($server, $connectionInfo);
 if ($conn === false) {
-    die( "skip Could not connect during SKIPIF." );
+    die("skip Could not connect during SKIPIF.");
 }
 
 $msodbcsql_ver = sqlsrv_client_info($conn)["DriverVer"];
@@ -35,9 +35,9 @@ if (!$is_win) {
 // Get SQL Server version
 // Exclude this check if running on Azure
 if (!$daasMode) {
-    $stmt = sqlsrv_query( $conn, "SELECT @@VERSION" );
+    $stmt = sqlsrv_query($conn, "SELECT @@VERSION");
     if (sqlsrv_fetch($stmt)) {
-        $ver_string = sqlsrv_get_field( $stmt, 0 );
+        $ver_string = sqlsrv_get_field($stmt, 0);
     } else {
         die("skip Could not fetch SQL Server version.");
     }


### PR DESCRIPTION
In Unix systems, installing mssql tools will automatically install ODBC 17. In order to properly skip some tests because of ODBC 13, the connection string has to specify the driver used.

See related PR #793 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/831)
<!-- Reviewable:end -->
