### PR TITLE
Modified the error handling to make it more flexible

### DIFF
--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -280,7 +280,7 @@ bool core_sqlsrv_get_odbc_error( _Inout_ sqlsrv_context& ctx, _In_ int record_nu
                 wnative_message_str = reinterpret_cast<SQLWCHAR*>(sqlsrv_malloc(expected_len));
                 memset(wnative_message_str, '\0', expected_len); 
 
-                SQLRETURN rtemp = ::SQLGetDiagFieldW(h_type, h, record_number, SQL_DIAG_MESSAGE_TEXT, wnative_message_str, wmessage_len + 1, &returned_len);
+                SQLRETURN rtemp = ::SQLGetDiagFieldW(h_type, h, record_number, SQL_DIAG_MESSAGE_TEXT, wnative_message_str, wmessage_len, &returned_len);
                 if (!SQL_SUCCEEDED(rtemp) || returned_len != expected_len) {
                     // something went wrong
                     return false;

--- a/test/functional/sqlsrv/sqlsrv_ae_type_conversion_select.phpt
+++ b/test/functional/sqlsrv/sqlsrv_ae_type_conversion_select.phpt
@@ -29,8 +29,10 @@ function checkErrors(&$convError)
         $convError[0][1] != '8114' and
         $convError[0][1] != '8169') {
         print_r($convError);
-        fatalError("Conversion failed with unexpected error message. i=$i, j=$j, v=$v\n");
-    }
+        return false;
+    } 
+    
+    return true;
 }
                 
 // Build the select queries. We want every combination of types for conversion
@@ -202,7 +204,9 @@ for ($v = 0; $v < sizeof($values); ++$v) {
             if ($stmt == false) {
                 $convError = sqlsrv_errors();
                 
-                checkErrors($convError);
+                if (!checkErrors($convError)) {
+                    fatalError("Conversion failed with unexpected error message. i=$i, j=$j, v=$v\n");
+                }
                 
                 if (AE\isDataEncrypted()) {
                     $stmtAE = sqlsrv_query($conn, $selectQueryAE[$i][$j]);


### PR DESCRIPTION
In most cases error messages are not long, so a small buffer usually suffices. Only with lengthy messages do we handle them differently.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/833)
<!-- Reviewable:end -->
