### PR TITLE
Incorporated changes in PR 634 to pdo_sqlsrv

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1396,10 +1396,10 @@ int pdo_sqlsrv_dbh_quote( _Inout_ pdo_dbh_t* dbh, _In_reads_(unquoted_len) const
             encoding = driver_dbh->encoding();
         }
         // get the placeholder at the current position in driver_stmt->placeholders ht
-        // do not directly alter the internal pointer in the array (See pull request 634 on GitHub)
-        HashPosition pos;
+        // Normally it's not a good idea to alter the internal pointer in a hashed array 
+        // (see pull request 634 on GitHub) but in this case this is for internal use only
         zval* placeholder = NULL;
-        if ((placeholder = zend_hash_get_current_data_ex(driver_stmt->placeholders, &pos)) != NULL && zend_hash_move_forward_ex(driver_stmt->placeholders, &pos) == SUCCESS && stmt->bound_params != NULL) {
+        if ((placeholder = zend_hash_get_current_data(driver_stmt->placeholders)) != NULL && zend_hash_move_forward(driver_stmt->placeholders) == SUCCESS && stmt->bound_params != NULL) {
             pdo_bound_param_data* param = NULL;
             if (Z_TYPE_P(placeholder) == IS_STRING) {
                 param = reinterpret_cast<pdo_bound_param_data*>(zend_hash_find_ptr(stmt->bound_params, Z_STR_P(placeholder)));

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1380,11 +1380,15 @@ int pdo_sqlsrv_dbh_quote( _Inout_ pdo_dbh_t* dbh, _In_reads_(unquoted_len) const
     }
     // only change the encoding if quote is called from the statement level (which should only be called when a statement
     // is prepared with emulate prepared on)
-    if ( is_statement ) {
-        pdo_stmt_t *stmt = Z_PDO_STMT_P( object );
+    if (is_statement) {
+        pdo_stmt_t *stmt = Z_PDO_STMT_P(object);
+        SQLSRV_ASSERT(stmt != NULL, "pdo_sqlsrv_dbh_quote: stmt object was null");
         // set the encoding to be the encoding of the statement otherwise set to be the encoding of the dbh
-        pdo_sqlsrv_stmt* driver_stmt = reinterpret_cast<pdo_sqlsrv_stmt*>( stmt->driver_data );
-        if ( driver_stmt->encoding() != SQLSRV_ENCODING_INVALID ) {
+
+        pdo_sqlsrv_stmt* driver_stmt = reinterpret_cast<pdo_sqlsrv_stmt*>(stmt->driver_data);
+        SQLSRV_ASSERT(driver_stmt != NULL, "pdo_sqlsrv_dbh_quote: driver_data object was null");
+
+        if (driver_stmt->encoding() != SQLSRV_ENCODING_INVALID) {
             encoding = driver_stmt->encoding();
         }
         else {
@@ -1392,18 +1396,20 @@ int pdo_sqlsrv_dbh_quote( _Inout_ pdo_dbh_t* dbh, _In_reads_(unquoted_len) const
             encoding = driver_dbh->encoding();
         }
         // get the placeholder at the current position in driver_stmt->placeholders ht
+        // do not directly alter the internal pointer in the array (See pull request 634 on GitHub)
+        HashPosition pos;
         zval* placeholder = NULL;
-        if (( placeholder = zend_hash_get_current_data( driver_stmt->placeholders )) != NULL && zend_hash_move_forward( driver_stmt->placeholders ) == SUCCESS && stmt->bound_params != NULL ) {
+        if ((placeholder = zend_hash_get_current_data_ex(driver_stmt->placeholders, &pos)) != NULL && zend_hash_move_forward_ex(driver_stmt->placeholders, &pos) == SUCCESS && stmt->bound_params != NULL) {
             pdo_bound_param_data* param = NULL;
-            if ( Z_TYPE_P( placeholder ) == IS_STRING ) {
-                param = reinterpret_cast<pdo_bound_param_data*>( zend_hash_find_ptr( stmt->bound_params, Z_STR_P( placeholder )));
+            if (Z_TYPE_P(placeholder) == IS_STRING) {
+                param = reinterpret_cast<pdo_bound_param_data*>(zend_hash_find_ptr(stmt->bound_params, Z_STR_P(placeholder)));
             }
-            else if ( Z_TYPE_P( placeholder ) == IS_LONG) {
-                param = reinterpret_cast<pdo_bound_param_data*>( zend_hash_index_find_ptr( stmt->bound_params, Z_LVAL_P( placeholder )));
+            else if (Z_TYPE_P(placeholder) == IS_LONG) {
+                param = reinterpret_cast<pdo_bound_param_data*>(zend_hash_index_find_ptr(stmt->bound_params, Z_LVAL_P(placeholder)));
             }
-            if ( NULL != param ) {
-                SQLSRV_ENCODING param_encoding = static_cast<SQLSRV_ENCODING>( Z_LVAL( param->driver_params ));
-                if ( param_encoding != SQLSRV_ENCODING_INVALID ) {
+            if (NULL != param) {
+                SQLSRV_ENCODING param_encoding = static_cast<SQLSRV_ENCODING>(Z_LVAL(param->driver_params));
+                if (param_encoding != SQLSRV_ENCODING_INVALID) {
                     encoding = param_encoding;
                 }
             }

--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -562,10 +562,10 @@ int pdo_sqlsrv_stmt_execute( _Inout_ pdo_stmt_t *stmt TSRMLS_DC )
         // subtituted query provided by PDO
         if (stmt->supports_placeholders == PDO_PLACEHOLDER_NONE) {
             // reset the placeholders hashtable internal in case the user reexecutes a statement
-            // do not directly alter the internal pointer in the array (See pull request 634 on GitHub)
-            HashPosition pos;
+            // Normally it's not a good idea to alter the internal pointer in a hashed array 
+            // (see pull request 634 on GitHub) but in this case this is for internal use only
 
-            zend_hash_internal_pointer_reset_ex(driver_stmt->placeholders, &pos);
+            zend_hash_internal_pointer_reset(driver_stmt->placeholders);
 
             query = stmt->active_query_string;
             query_len = static_cast<unsigned int>(stmt->active_query_stringlen);

--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -560,12 +560,15 @@ int pdo_sqlsrv_stmt_execute( _Inout_ pdo_stmt_t *stmt TSRMLS_DC )
 
         // if the user is using prepare emulation (PDO::ATTR_EMULATE_PREPARES), set the query to the 
         // subtituted query provided by PDO
-        if( stmt->supports_placeholders == PDO_PLACEHOLDER_NONE ) {
+        if (stmt->supports_placeholders == PDO_PLACEHOLDER_NONE) {
             // reset the placeholders hashtable internal in case the user reexecutes a statement
-            zend_hash_internal_pointer_reset(driver_stmt->placeholders);
+            // do not directly alter the internal pointer in the array (See pull request 634 on GitHub)
+            HashPosition pos;
+
+            zend_hash_internal_pointer_reset_ex(driver_stmt->placeholders, &pos);
 
             query = stmt->active_query_string;
-            query_len = static_cast<unsigned int>( stmt->active_query_stringlen );
+            query_len = static_cast<unsigned int>(stmt->active_query_stringlen);
         }
 
         SQLRETURN execReturn = core_sqlsrv_execute( driver_stmt TSRMLS_CC, query, query_len );


### PR DESCRIPTION
Unlike the related PR #634, this array is for internal use only. Moreover, the reset function is called in a different method, so do not have `pos` (HashPosition) initialized.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/834)
<!-- Reviewable:end -->
