### PR TITLE
Remove Web server prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ For full details on the system requirements for the drivers, see the [system req
 
 On the client machine:
 - PHP 7.0.x, 7.1.x, or 7.2.x (7.2.0 and up on Unix, 7.2.1 and up on Windows)
-- A Web server such as Internet Information Services (IIS) is required. Your Web server must be configured to run PHP
 - [Microsoft ODBC Driver 17, Microsoft ODBC Driver 13, or Microsoft ODBC Driver 11](https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-2017)
 
 On the server side, Microsoft SQL Server 2008 R2 and above on Windows are supported, as are Microsoft SQL Server 2016 and above on Linux.


### PR DESCRIPTION
Web server is not required to use the MSSQL Driver and it's definitely a _prerequisite_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/msphpsql/839)
<!-- Reviewable:end -->
