### PR TITLE
Initialize output param buffer when allocating extra space

### DIFF
--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -2774,7 +2774,6 @@ void resize_output_buffer_if_necessary( _Inout_ sqlsrv_stmt* stmt, _Inout_ zval*
     SQLLEN expected_len;
     SQLLEN buffer_null_extra;
     SQLLEN elem_size;
-    // SQLLEN without_null_len;
 
     // calculate the size of each 'element' represented by column_size.  WCHAR is of course 2,
     // as is a n(var)char/ntext field being returned as a binary field.
@@ -2802,9 +2801,6 @@ void resize_output_buffer_if_necessary( _Inout_ sqlsrv_stmt* stmt, _Inout_ zval*
     // binary fields aren't null terminated, so we need to account for that in our buffer length calcuations
     buffer_null_extra = (c_type == SQL_C_BINARY) ? elem_size : 0;
 
-    // this is the size of the string for Zend and for the StrLen parameter to SQLBindParameter
-    // without_null_len = field_size * elem_size;
-
     // increment to include the null terminator since the Zend length doesn't include the null terminator
     buffer_len += elem_size;
 
@@ -2822,7 +2818,7 @@ void resize_output_buffer_if_necessary( _Inout_ sqlsrv_stmt* stmt, _Inout_ zval*
         // A zval string len doesn't include the null.  This calculates the length it should be
         // regardless of whether the ODBC type contains the NULL or not.
 
-        // set the newly allocated space to nulls
+        // initialize the newly allocated space 
         char *p = ZSTR_VAL(param_z_string); 
         p = p + original_len;
         memset(p, '\0', expected_len - original_len);

--- a/test/functional/pdo_sqlsrv/pdo_900_output_param_memory_data.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_900_output_param_memory_data.phpt
@@ -10,6 +10,7 @@ PHPT_EXEC=true
 --FILE--
 <?php
 require_once("MsSetup.inc");
+require_once("MsCommon_mid-refactor.inc");
 
 $size = 30;
 

--- a/test/functional/pdo_sqlsrv/pdo_900_output_param_memory_data.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_900_output_param_memory_data.phpt
@@ -1,0 +1,84 @@
+--TEST--
+GitHub issue 900 - output parameter displays data from memory when not finalized
+--DESCRIPTION--
+This test verifies that when there is an active resultset and output parameter not finalized, it should not show any data from client memory. This test does not work with AlwaysEncrypted because
+the output param is not assigned in the stored procedure.
+--ENV--
+PHPT_EXEC=true
+--SKIPIF--
+<?php require('skipif_mid-refactor.inc'); ?>
+--FILE--
+<?php
+require_once("MsSetup.inc");
+
+$size = 30;
+
+function getOutputParam($conn, $storedProcName, $dataType, $inout)
+{
+    global $size;
+
+    try {
+        $output = null;
+
+        $stmt = $conn->prepare("$storedProcName @OUTPUT = :output");
+        // $stmt->bindParam('output', $output, PDO::PARAM_STR, $size);
+        if ($inout) {
+            $paramType = PDO::PARAM_STR | PDO::PARAM_INPUT_OUTPUT;
+        } else {
+            $paramType = PDO::PARAM_STR;
+        }
+        $stmt->bindParam('output', $output, $paramType, $size);
+
+        $stmt->execute();
+
+        // the output param should be doubled in size for wide characters
+        // however, it should not contain any data so after trimming it
+        // should be merely an empty string
+        $len = strlen($output);
+        $result = trim($output);
+
+        if ($len != ($size * 2) || $result !== "" ) {
+            echo "Unexpected output param for $dataType: ";
+            var_dump($output);
+        }
+        
+        $stmt->closeCursor();
+        if (!is_null($output)) {
+            echo "Output param should be null when finalized!";
+        }
+        unset($stmt);
+    } catch (PdoException $e) {
+        echo $e->getMessage() . PHP_EOL;
+    }
+}
+
+try {
+    // This helper method sets PDO::ATTR_ERRMODE to PDO::ERRMODE_EXCEPTION
+    // $conn = connect();
+    $conn = new PDO( "sqlsrv:server=$server; Database = $databaseName", $uid, $pwd);
+    $conn->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+
+    $dataTypes = array("VARCHAR(512)", "VARCHAR(max)", "NVARCHAR(512)", "NVARCHAR(max)");
+    for ($i = 0, $p = 3; $i < count($dataTypes); $i++, $p++) {
+        // Create the stored procedure first
+        $storedProcName = "spNullOutputParam" . $i;
+        $procArgs = "@OUTPUT $dataTypes[$i] OUTPUT";
+        $procCode = "SELECT 1, 2, 3";
+
+        createProc($conn, $storedProcName, $procArgs, $procCode);
+        getOutputParam($conn, $storedProcName, $dataTypes[$i], false);
+        getOutputParam($conn, $storedProcName, $dataTypes[$i], true);
+
+        // Drop the stored procedure
+        dropProc($conn, $storedProcName);
+    }
+
+    echo "Done\n";
+
+    unset($conn);
+} catch (PdoException $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+?>
+--EXPECT--
+Done

--- a/test/functional/sqlsrv/sqlsrv_900_output_param_memory_data.phpt
+++ b/test/functional/sqlsrv/sqlsrv_900_output_param_memory_data.phpt
@@ -1,0 +1,81 @@
+--TEST--
+GitHub issue 900 - output parameter displays data from memory when not finalized
+--DESCRIPTION--
+This test verifies that when there is an active resultset and output parameter not finalized, it should not show any data from client memory. This test does not work with AlwaysEncrypted because
+the output param is not assigned in the stored procedure.
+--ENV--
+PHPT_EXEC=true
+--SKIPIF--
+<?php require('skipif_versions_old.inc'); ?>
+--FILE--
+<?php
+require_once('MsCommon.inc');
+
+$size = 30;
+
+function getOutputParam($conn, $storedProcName, $inout, $isVarchar, $isMax)
+{
+    global $size;
+    
+    $output = null;
+    $dir = ($inout)? SQLSRV_PARAM_INOUT : SQLSRV_PARAM_OUT;
+    $dataType = ($isVarchar)? "SQLSRV_SQLTYPE_VARCHAR" : "SQLSRV_SQLTYPE_NVARCHAR";
+    $sqlType = ($isMax)? call_user_func($dataType, 'max') : call_user_func($dataType, $size);
+
+    $stmt = sqlsrv_prepare($conn, "$storedProcName @OUTPUT = ?", array(array(&$output, $dir, null, $sqlType)));
+    if (!$stmt) {
+        fatalError("getOutputParam: failed when preparing to call $storedProcName");
+    }
+    if (!sqlsrv_execute($stmt)) {
+        fatalError("getOutputParam: failed to execute procedure $storedProcName");
+    }
+
+    // The output param should be doubled in size for wide characters;
+    // for max fields it should be the maximum anticipated size 8000.
+    // However, it should not contain any data so after trimming it
+    // should be merely an empty string
+    $len = strlen($output);
+    $expectedLen = ($isMax)? 8000 :  ($size * 2);
+    $result = trim($output);
+
+    if ($len != $expectedLen || $result !== "" ) {
+        echo "Unexpected output param for $dataType, $isMax: ";
+        var_dump($output);
+    }
+    
+    sqlsrv_next_result($stmt);
+    if (!is_null($output)) {
+        echo "Output param should be null when finalized!";
+    }
+}
+
+set_time_limit(0);
+sqlsrv_configure('WarningsReturnAsErrors', 1);
+
+$conn = connect(array("CharacterSet" => "UTF-8"));
+if (!$conn) {
+    fatalError("Could not connect.\n");
+}
+
+$dataTypes = array("VARCHAR(512)", "VARCHAR(max)", "NVARCHAR(512)", "NVARCHAR(max)");
+for ($i = 0, $p = 3; $i < count($dataTypes); $i++, $p++) {
+    // Create the stored procedure first
+    $storedProcName = "spNullOutputParam" . $i;
+    $procArgs = "@OUTPUT $dataTypes[$i] OUTPUT";
+    $procCode = "SELECT 1, 2, 3";
+
+    createProc($conn, $storedProcName, $procArgs, $procCode);
+    getOutputParam($conn, $storedProcName, false, ($i < 2), ($i % 2 != 0));
+    getOutputParam($conn, $storedProcName, true, ($i < 2), ($i % 2 != 0));
+
+    // Drop the stored procedure
+    dropProc($conn, $storedProcName);
+}
+
+echo "Done\n";
+
+sqlsrv_close($conn);
+
+?>
+--EXPECT--
+Done


### PR DESCRIPTION
See related issue #900 