### PR TITLE
Dropped dbname variable and set QUOTED_IDENTIFIER to ON

### DIFF
--- a/test/functional/setup/168256.sql
+++ b/test/functional/setup/168256.sql
@@ -1,6 +1,3 @@
-USE $(dbname) 
-GO
-
 IF EXISTS (SELECT * FROM sys.objects 
 WHERE object_id = OBJECT_ID(N'[dbo].[168256]') AND type in (N'U'))
 

--- a/test/functional/setup/cd_info.sql
+++ b/test/functional/setup/cd_info.sql
@@ -1,11 +1,8 @@
-USE $(dbname) 
-GO
-
 IF EXISTS (SELECT * FROM sys.objects 
 WHERE object_id = OBJECT_ID(N'[dbo].[tracks]') AND type in (N'U'))
 
 BEGIN
-ALTER TABLE $(dbname)..[tracks] DROP CONSTRAINT [FK__tracks__asin__7F60ED59]
+ALTER TABLE [tracks] DROP CONSTRAINT [FK__tracks__asin__7F60ED59]
 END
 
 GO

--- a/test/functional/setup/cleanup_dbs.py
+++ b/test/functional/setup/cleanup_dbs.py
@@ -3,10 +3,10 @@
 
 import os
 import sys
-import subprocess
-import platform
+# import subprocess
+# import platform
 import argparse
-from subprocess import Popen, PIPE
+# from subprocess import Popen, PIPE
 from exec_sql_scripts import *
 
 if __name__ == '__main__':
@@ -25,8 +25,8 @@ if __name__ == '__main__':
         sys.exit(1)
 
     conn_options = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + ' '  
-    
-    executeSQLscript( os.path.join( os.path.dirname(os.path.realpath(__file__)), 'drop_db.sql'), conn_options, args.DBNAME)
+
+    manageTestDB('drop_db.sql', conn_options, args.DBNAME)
 
     # if Windows, remove self signed certificate using ps command
     if platform.system() == 'Windows':

--- a/test/functional/setup/cleanup_dbs.py
+++ b/test/functional/setup/cleanup_dbs.py
@@ -24,7 +24,8 @@ if __name__ == '__main__':
 
     conn_options = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + ' '  
 
-    manageTestDB('drop_db.sql', conn_options, args.DBNAME)
+    sql_script = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'drop_db.sql');
+    manageTestDB(sql_script, conn_options, args.DBNAME)
 
     # if Windows, remove self signed certificate using ps command
     if platform.system() == 'Windows':

--- a/test/functional/setup/cleanup_dbs.py
+++ b/test/functional/setup/cleanup_dbs.py
@@ -3,10 +3,8 @@
 
 import os
 import sys
-# import subprocess
-# import platform
+import platform
 import argparse
-# from subprocess import Popen, PIPE
 from exec_sql_scripts import *
 
 if __name__ == '__main__':

--- a/test/functional/setup/create_db.sql
+++ b/test/functional/setup/create_db.sql
@@ -1,13 +1,5 @@
-USE [master]
-GO
+IF EXISTS (SELECT name FROM sys.databases WHERE name = 'TEST_DB' ) DROP DATABASE TEST_DB
 
-IF EXISTS (SELECT name FROM sys.databases WHERE name = '$(dbname)' )
-
-BEGIN
-DROP DATABASE $(dbname)
-END
-
-CREATE DATABASE $(dbname)
-
+CREATE DATABASE TEST_DB
 GO
 

--- a/test/functional/setup/drop_db.sql
+++ b/test/functional/setup/drop_db.sql
@@ -1,8 +1,1 @@
-USE [master]
-GO
-
-IF EXISTS (SELECT name FROM sys.databases WHERE name = '$(dbname)' )
-
-BEGIN
-DROP DATABASE $(dbname)
-END
+IF EXISTS (SELECT name FROM sys.databases WHERE name = 'TEST_DB' ) DROP DATABASE TEST_DB

--- a/test/functional/setup/exec_sql_scripts.py
+++ b/test/functional/setup/exec_sql_scripts.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
-# contains helper methods  
+# contains helper methods
 import os
-import sys
 import subprocess
-import platform
-import argparse
 from subprocess import Popen, PIPE
 
 def executeCommmand(inst_command):
@@ -15,29 +12,17 @@ def executeCommmand(inst_command):
     print (oo)
 
 def executeSQLscript(sqlfile, conn_options, dbname):
-    if platform.system() == 'Windows':
-        executeSQLscriptWindows(sqlfile, conn_options, dbname)
-    elif platform.system() == 'Linux' or platform.system() == 'Darwin':
-        executeSQLscriptUnix(sqlfile, conn_options, dbname)
-    
-def executeSQLscriptWindows(sqlfile, conn_options, dbname):
-    inst_command  = 'sqlcmd ' + conn_options + ' -i ' + sqlfile + ' -v dbname =' + dbname
+    inst_command  = 'sqlcmd -I ' + conn_options + ' -i ' + sqlfile + ' -d ' + dbname
     executeCommmand(inst_command)
 
-def executeSQLscriptUnix(sqlfile, conn_options, dbname):
-    # This is a workaround because sqlcmd in Unix does not support -v option for variables. 
-    # It inserts setvar dbname into the beginning of a temp .sql file
-    tmpFileName = sqlfile[0:-4] + '_tmp.sql'
-    redirect_string = '(echo :setvar dbname {0})  > {2}; cat {1} >> {2}; '
-    sqlcmd = 'sqlcmd ' + conn_options + ' -i ' + tmpFileName
+def manageTestDB(sqlfile, conn_options, dbname):
+    tmp_sql_file = 'test_db_tmp.sql'
+    if os.path.exists(tmp_sql_file):
+        os.remove(tmp_sql_file)
+    with open(sqlfile, 'r') as infile:
+        script = infile.read().replace('TEST_DB', dbname)
+    with open(tmp_sql_file, 'w') as outfile:
+        outfile.write(script)
 
-    # Execute a simple query via sqlcmd: without this step, the next step fails in travis CI
-    simple_cmd = 'sqlcmd ' + conn_options + ' -Q \"select @@Version\" '
-    executeCommmand(simple_cmd)
-
-    # inst_command = redirect_string.format(dbname, sqlfile, tmpFileName) + sqlcmd
-    inst_command = redirect_string.format(dbname, sqlfile, tmpFileName)
-    executeCommmand(inst_command)
-    executeCommmand(sqlcmd)
-    
-    os.remove(tmpFileName)
+    executeSQLscript(tmp_sql_file, conn_options, 'master')
+    os.remove(tmp_sql_file)

--- a/test/functional/setup/setup_dbs.py
+++ b/test/functional/setup/setup_dbs.py
@@ -4,10 +4,8 @@
 # py setup_dbs.py -dbname <DBNAME>
 import os
 import sys
-import subprocess
 import platform
 import argparse
-from subprocess import Popen, PIPE
 from exec_sql_scripts import *
 
 def setupTestDatabase(conn_options, dbname, azure):
@@ -24,8 +22,6 @@ def populateTables(conn_options, dbname):
     executeBulkCopy(conn_options, dbname, '168256', '168256')
 
 def executeBulkCopy(conn_options, dbname, tblname, datafile):
-    #redirect_string = 'bcp {0}..[{1}] in {2}.dat -f {2}.fmt -q'
-    #redirect_string = 'bcp {1} in {2}.dat -f {2}.fmt -q -d {0} '
     redirect_string = 'bcp {0}..{1} in {2}.dat -f {2}.fmt -q'
     inst_command = redirect_string.format(dbname, tblname, datafile) + conn_options
     executeCommmand(inst_command)

--- a/test/functional/setup/setup_dbs.py
+++ b/test/functional/setup/setup_dbs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # py setup_dbs.py -dbname <DBNAME> -azure <yes or no>
-# OR 
-# py setup_dbs.py -dbname <DBNAME> 
+# OR
+# py setup_dbs.py -dbname <DBNAME>
 import os
 import sys
 import subprocess
@@ -12,10 +12,6 @@ from exec_sql_scripts import *
 
 def setupTestDatabase(conn_options, dbname, azure):
     sqlFiles = ['test_types.sql', '168256.sql', 'cd_info.sql', 'tracks.sql']
-    
-    # for Azure, must specify the database for the sql scripts to work
-    if (azure.lower() == 'yes'):
-        conn_options += ' -d ' + dbname
 
     for sqlFile in sqlFiles:
         executeSQLscript(sqlFile, conn_options, dbname)
@@ -28,29 +24,31 @@ def populateTables(conn_options, dbname):
     executeBulkCopy(conn_options, dbname, '168256', '168256')
 
 def executeBulkCopy(conn_options, dbname, tblname, datafile):
-    redirect_string = 'bcp {0}..[{1}] in {2}.dat -f {2}.fmt '
-    inst_command = redirect_string.format(dbname, tblname, datafile) + conn_options 
+    #redirect_string = 'bcp {0}..[{1}] in {2}.dat -f {2}.fmt -q'
+    #redirect_string = 'bcp {1} in {2}.dat -f {2}.fmt -q -d {0} '
+    redirect_string = 'bcp {0}..{1} in {2}.dat -f {2}.fmt -q'
+    inst_command = redirect_string.format(dbname, tblname, datafile) + conn_options
     executeCommmand(inst_command)
-    
+
 def setupAE(conn_options, dbname):
     if (platform.system() == 'Windows'):
         # import self signed certificate
         inst_command = "certutil -user -p '' -importPFX My PHPcert.pfx NoRoot"
         executeCommmand(inst_command)
         # create Column Master Key and Column Encryption Key
-        script_command = 'sqlcmd ' + conn_options + ' -i ae_keys.sql -d ' + dbname
+        script_command = 'sqlcmd -I ' + conn_options + ' -i ae_keys.sql -d ' + dbname
         executeCommmand(script_command)
-    
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-dbname', '--DBNAME', required=True)
     parser.add_argument('-azure', '--AZURE', required=False, default='no')
     args = parser.parse_args()
-    
-    try:    
-        server = os.environ['TEST_PHP_SQL_SERVER'] 
-        uid = os.environ['TEST_PHP_SQL_UID'] 
-        pwd = os.environ['TEST_PHP_SQL_PWD'] 
+
+    try:
+        server = os.environ['TEST_PHP_SQL_SERVER']
+        uid = os.environ['TEST_PHP_SQL_UID']
+        pwd = os.environ['TEST_PHP_SQL_PWD']
     except :
         print("TEST_PHP_SQL_SERVER environment variable must be set to the name of the server to use")
         print("TEST_PHP_SQL_UID environment variable must be set to the name of the user to authenticate with")
@@ -59,18 +57,17 @@ if __name__ == '__main__':
 
     current_working_dir=os.getcwd()
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
-    conn_options = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + ' '  
-    
+    conn_options = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + ' '
+
     # In Azure, assume an empty test database has been created using Azure portal
     if (args.AZURE.lower() == 'no'):
-        executeSQLscript('create_db.sql', conn_options, args.DBNAME)
+        manageTestDB('create_db.sql', conn_options, args.DBNAME)
 
     # create tables in the new database
-    setupTestDatabase(conn_options, args.DBNAME, args.AZURE)    
+    setupTestDatabase(conn_options, args.DBNAME, args.AZURE)
     # populate these tables
     populateTables(conn_options, args.DBNAME)
     # setup AE (certificate, column master key and column encryption key)
     setupAE(conn_options, args.DBNAME)
-    
+
     os.chdir(current_working_dir)
-    

--- a/test/functional/setup/test_types.sql
+++ b/test/functional/setup/test_types.sql
@@ -1,28 +1,25 @@
-USE $(dbname) 
-GO
-
 CREATE TABLE [test_types] ([bigint_type] BIGINT null,
-                                      [int_type] INT null,
-                                      [smallint_type] SMALLINT null,
-                                      [tinyint_type] TINYINT null,
-                                      [bit_type] BIT null,
-                                      [decimal_type] DECIMAL(38,0) null,
-                                      [money_type] MONEY null,
-                                      [smallmoney_type] SMALLMONEY null,
-                                      [float_type] FLOAT(53) null,
-                                      [real_type] REAL null,
-                                      [datetime_type] DATETIME null,
-                                      [smalldatetime_type] SMALLDATETIME null );
+                           [int_type] INT null,
+                           [smallint_type] SMALLINT null,
+                           [tinyint_type] TINYINT null,
+                           [bit_type] BIT null,
+                           [decimal_type] DECIMAL(38,0) null,
+                           [money_type] MONEY null,
+                           [smallmoney_type] SMALLMONEY null,
+                           [float_type] FLOAT(53) null,
+                           [real_type] REAL null,
+                           [datetime_type] DATETIME null,
+                           [smalldatetime_type] SMALLDATETIME null );
 GO
 
 -- maximum test
-INSERT INTO $(dbname)..[test_types] (bigint_type, int_type, smallint_type, tinyint_type, bit_type, decimal_type, datetime_type, money_type, smallmoney_type, float_type, real_type) 
+INSERT INTO [test_types] (bigint_type, int_type, smallint_type, tinyint_type, bit_type, decimal_type, datetime_type, money_type, smallmoney_type, float_type, real_type) 
 			VALUES (9223372036854775807, 2147483647, 32767, 255, 1, 9999999999999999999999999999999999999, '12/12/1968 16:20', 922337203685477.5807, 214748.3647, 1.79E+308, 1.18E-38 )
 -- minimum test
-INSERT INTO $(dbname)..[test_types] (bigint_type, int_type, smallint_type, tinyint_type, bit_type, decimal_type, datetime_type, money_type, smallmoney_type, float_type, real_type)
+INSERT INTO [test_types] (bigint_type, int_type, smallint_type, tinyint_type, bit_type, decimal_type, datetime_type, money_type, smallmoney_type, float_type, real_type)
 			VALUES (-9223372036854775808, -2147483648, -32768, 0, 0, -10000000000000000000000000000000000001,'12/12/1968 16:20', -922337203685477.5808, -214748.3648, -1.79E+308, -1.18E-38 )
 -- zero test
-INSERT INTO $(dbname)..[test_types] (bigint_type, int_type, smallint_type, tinyint_type, bit_type, decimal_type, datetime_type, money_type, smallmoney_type, float_type, real_type) 
+INSERT INTO [test_types] (bigint_type, int_type, smallint_type, tinyint_type, bit_type, decimal_type, datetime_type, money_type, smallmoney_type, float_type, real_type) 
 			VALUES (0, 0, 0, 0, 0, 0, '12/12/1968 16:20', 0, 0, 0, 0)
 
 GO

--- a/test/functional/setup/tracks.sql
+++ b/test/functional/setup/tracks.sql
@@ -1,6 +1,3 @@
-USE $(dbname) 
-GO
-
 IF EXISTS (SELECT * FROM sys.objects 
 WHERE object_id = OBJECT_ID(N'[dbo].[tracks]') AND type in (N'U'))
 


### PR DESCRIPTION
To prepare these scripts for future development purpose:
1. Modify the scripts to SET QUOTED_IDENTIFIER to 'ON' -- run sqlcmd with -I and bcp with -q
1. Also drop 'Use DbName' or the use of dbname variable
