### PR TITLE
Fixed load order issue in sqlsrv

### DIFF
--- a/source/sqlsrv/config.m4
+++ b/source/sqlsrv/config.m4
@@ -40,7 +40,7 @@ if test "$PHP_SQLSRV" != "no"; then
            shared/StringFunctions.cpp \
            "
     AC_MSG_CHECKING([for SQLSRV headers])
-    if test -f $srcdir/ext/pdo_sqlsrv/shared/core_sqlsrv.h && test "$PHP_PDO_SQLSRV" != "no"; then
+    if test -f $srcdir/ext/pdo_sqlsrv/shared/core_sqlsrv.h && test "$PHP_PDO_SQLSRV" != "no" && test "$PHP_PDO_SQLSRV_SHARED" == "no"; then
       pdo_sqlsrv_inc_path=$srcdir/ext/pdo_sqlsrv/shared/
       shared_src_class=""
     elif test -f $srcdir/ext/sqlsrv/shared/core_sqlsrv.h; then


### PR DESCRIPTION
Have tested all load order combinations and they all work:
Two shared files: pdo+sqlsrv, sqlsrv+pdo, pdo only, sqlsrv only
one static+one shared: pdo shared, sqlsrv shared
both static