### PR TITLE
Changed travis to pull mcr.microsoft.com/mssql/server:2017-latest 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
   - TEST_PHP_SQL_PWD=Password123
 
 before_install:
-  - docker pull microsoft/mssql-server-linux:2017-latest
+  - docker pull mcr.microsoft.com/mssql/server:2017-latest
  
 install:
-  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password123' -p 1433:1433 --name=$TEST_PHP_SQL_SERVER -d microsoft/mssql-server-linux:2017-latest
+  - docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=Password123' -p 1433:1433 --name=$TEST_PHP_SQL_SERVER -d mcr.microsoft.com/mssql/server:2017-latest
   - docker build --build-arg PHPSQLDIR=$PHPSQLDIR -t msphpsql-dev -f Dockerfile-msphpsql .
 
 before_script:


### PR DESCRIPTION
As indicated on [mssql-server-linux](https://hub.docker.com/r/microsoft/mssql-server-linux/), microsoft/mssql-server-linux will eventually be deprecated