### PR TITLE
Fixed the returned values for PDOStatement::getColumnMeta

### DIFF
--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -1020,7 +1020,7 @@ int pdo_sqlsrv_stmt_get_attr( _Inout_ pdo_stmt_t *stmt, _In_ zend_long attr, _In
 // colno        - The index of the field for which to return the metadata.
 // return_value - zval* consisting of the metadata.
 // Return:
-// 0 for failure, 1 for success.
+// FAILURE for failure, SUCCESS for success.
 int pdo_sqlsrv_stmt_get_col_meta( _Inout_ pdo_stmt_t *stmt, _In_ zend_long colno, _Inout_ zval *return_value TSRMLS_DC)
 {
     PDO_RESET_STMT_ERROR;
@@ -1096,14 +1096,14 @@ int pdo_sqlsrv_stmt_get_col_meta( _Inout_ pdo_stmt_t *stmt, _In_ zend_long colno
     }
     catch( core::CoreException& ) {
 
-        return 0;
+        return FAILURE;
     }
     catch(...) {
 
         DIE( "pdo_sqlsrv_stmt_get_col_meta: Unknown exception occurred while retrieving metadata." );
     }
     
-    return 1;
+    return SUCCESS;
 }
 
 


### PR DESCRIPTION
PDO expects different returned values from PDOStatement::getColumnMeta()
- the other methods in the API returns 0 for failure and 1 for success
- but getColumnMeta should return FAILURE (-1) or SUCCESS(0) instead (enum ZEND_RESULT_CODE)

Confirmed this part of the PDO code is the same in PHP 7.1, 7.2 and 7.3

```
static PHP_METHOD(PDOStatement, getColumnMeta)
{
...
	PDO_STMT_CLEAR_ERR();
	if (FAILURE == stmt->methods->get_column_meta(stmt, colno, return_value)) {
		PDO_HANDLE_STMT_ERR();
		RETURN_FALSE;
	}
...
}
```

Reported to PHP 
https://bugs.php.net/bug.php?id=77710