### PR TITLE
Improve data caching with datetime objects

### DIFF
--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -220,7 +220,7 @@ void meta_data_free( _Inout_ field_meta_data* meta )
     sqlsrv_free( meta );
 }
 
-zval convert_to_zval( _In_ SQLSRV_PHPTYPE sqlsrv_php_type, _Inout_ void** in_val, _In_opt_ SQLLEN field_len )
+zval convert_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_ SQLSRV_PHPTYPE sqlsrv_php_type, _Inout_ void** in_val, _In_opt_ SQLLEN field_len )
 {
     zval out_zval;
     ZVAL_UNDEF(&out_zval);
@@ -264,15 +264,15 @@ zval convert_to_zval( _In_ SQLSRV_PHPTYPE sqlsrv_php_type, _Inout_ void** in_val
         break;
     }
     case SQLSRV_PHPTYPE_DATETIME:
-        if (*in_val == NULL) {
+        //if (*in_val == NULL) {
 
-            ZVAL_NULL(&out_zval);
-        }
-        else {
+        //    ZVAL_NULL(&out_zval);
+        //}
+        //else {
 
-            out_zval = *(reinterpret_cast<zval*>(*in_val));
+            convert_datetime_string_to_zval(stmt, reinterpret_cast<char*>(*in_val), field_len, out_zval);
             sqlsrv_free(*in_val);
-        }
+        //}
         break;
     case SQLSRV_PHPTYPE_NULL:
         ZVAL_NULL(&out_zval);
@@ -833,11 +833,11 @@ int pdo_sqlsrv_stmt_get_col_data( _Inout_ pdo_stmt_t *stmt, _In_ int colno,
         core_sqlsrv_get_field( driver_stmt, colno, sqlsrv_php_type, false, *(reinterpret_cast<void**>(ptr)),
                                reinterpret_cast<SQLLEN*>( len ), true, &sqlsrv_phptype_out TSRMLS_CC );
 
-        if ( ptr ) {
-            zval* zval_ptr = reinterpret_cast<zval*>( sqlsrv_malloc( sizeof( zval )));
-            *zval_ptr = convert_to_zval( sqlsrv_phptype_out, reinterpret_cast<void**>( ptr ), *len );
-            *ptr = reinterpret_cast<char*>( zval_ptr );
-            *len = sizeof( zval );
+        if (ptr) {
+            zval* zval_ptr = reinterpret_cast<zval*>(sqlsrv_malloc(sizeof(zval)));
+            *zval_ptr = convert_to_zval(driver_stmt, sqlsrv_phptype_out, reinterpret_cast<void**>(ptr), *len);
+            *ptr = reinterpret_cast<char*>(zval_ptr);
+            *len = sizeof(zval);
         }
 
         return 1;        

--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -264,15 +264,8 @@ zval convert_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_ SQLSRV_PHPTYPE sqlsrv_php_t
         break;
     }
     case SQLSRV_PHPTYPE_DATETIME:
-        //if (*in_val == NULL) {
-
-        //    ZVAL_NULL(&out_zval);
-        //}
-        //else {
-
-            convert_datetime_string_to_zval(stmt, reinterpret_cast<char*>(*in_val), field_len, out_zval);
-            sqlsrv_free(*in_val);
-        //}
+        convert_datetime_string_to_zval(stmt, static_cast<char*>(*in_val), field_len, out_zval);
+        sqlsrv_free(*in_val);
         break;
     case SQLSRV_PHPTYPE_NULL:
         ZVAL_NULL(&out_zval);

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -1810,6 +1810,8 @@ bool validate_string( _In_ char* string, _In_ SQLLEN& len);
 bool convert_string_from_utf16( _In_ SQLSRV_ENCODING encoding, _In_reads_bytes_(cchInLen) const SQLWCHAR* inString, _In_ SQLINTEGER cchInLen, _Inout_updates_bytes_(cchOutLen) char** outString, _Out_ SQLLEN& cchOutLen );
 SQLWCHAR* utf16_string_from_mbcs_string( _In_ SQLSRV_ENCODING php_encoding, _In_reads_bytes_(mbcs_len) const char* mbcs_string, _In_ unsigned int mbcs_len, _Out_ unsigned int* utf16_len, bool use_strict_conversion = false );
 
+void convert_datetime_string_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_opt_ char* input, _In_ SQLLEN length, _Inout_ zval& out_zval);
+
 //*********************************************************************************************************************************
 // Error handling routines and Predefined Errors
 //*********************************************************************************************************************************

--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -189,6 +189,8 @@ SQLWCHAR* utf16_string_from_mbcs_string( _In_ SQLSRV_ENCODING php_encoding, _In_
     return utf16_string;
 }
 
+// Converts an input datetime string to a valid zval containing a PHP DateTime object.
+// If the input is null, simply returns a NULL zval
 void convert_datetime_string_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_opt_ char* input, _In_ SQLLEN length, _Inout_ zval& out_zval)
 {
     zval params[1];

--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -189,23 +189,25 @@ SQLWCHAR* utf16_string_from_mbcs_string( _In_ SQLSRV_ENCODING php_encoding, _In_
     return utf16_string;
 }
 
-// Converts an input datetime string to a valid zval containing a PHP DateTime object.
-// If the input is null, simply returns a NULL zval
+// Converts an input (assuming a datetime string) to a zval containing a PHP DateTime object. 
+// If the input is null, this simply returns a NULL zval. If anything wrong occurs during conversion,
+// an exception will be thrown.
 void convert_datetime_string_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_opt_ char* input, _In_ SQLLEN length, _Inout_ zval& out_zval)
 {
-    zval params[1];
-    zval value_temp_z;
-    zval function_z;
-
-    ZVAL_UNDEF(&out_zval);
-    ZVAL_UNDEF(&value_temp_z);
-    ZVAL_UNDEF(&function_z);
-    ZVAL_UNDEF(params);
-
     if (input == NULL) {
         ZVAL_NULL(&out_zval);
         return;
     }
+
+    zval params[1];
+    zval value_temp_z;
+    zval function_z;
+
+    // Initialize all zval variables
+    ZVAL_UNDEF(&out_zval);
+    ZVAL_UNDEF(&value_temp_z);
+    ZVAL_UNDEF(&function_z);
+    ZVAL_UNDEF(params);
 
     // Convert the datetime string to a PHP DateTime object
     core::sqlsrv_zval_stringl(&value_temp_z, input, length);

--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -189,6 +189,36 @@ SQLWCHAR* utf16_string_from_mbcs_string( _In_ SQLSRV_ENCODING php_encoding, _In_
     return utf16_string;
 }
 
+void convert_datetime_string_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_opt_ char* input, _In_ SQLLEN length, _Inout_ zval& out_zval)
+{
+    zval params[1];
+    zval value_temp_z;
+    zval function_z;
+
+    ZVAL_UNDEF(&out_zval);
+    ZVAL_UNDEF(&value_temp_z);
+    ZVAL_UNDEF(&function_z);
+    ZVAL_UNDEF(params);
+
+    if (input == NULL) {
+        ZVAL_NULL(&out_zval);
+        return;
+    }
+
+    // Convert the datetime string to a PHP DateTime object
+    core::sqlsrv_zval_stringl(&value_temp_z, input, length);
+    core::sqlsrv_zval_stringl(&function_z, "date_create", sizeof("date_create") - 1);
+    params[0] = value_temp_z;
+
+    if (call_user_function(EG(function_table), NULL, &function_z, &out_zval, 1,
+                           params TSRMLS_CC) == FAILURE) {
+        THROW_CORE_ERROR(stmt, SQLSRV_ERROR_DATETIME_CONVERSION_FAILED);
+    }
+
+    zend_string_free(Z_STR(value_temp_z));
+    zend_string_free(Z_STR(function_z));
+}
+
 // call to retrieve an error from ODBC.  This uses SQLGetDiagRec, so the
 // errno is 1 based.  It returns it as an array with 3 members:
 // 1/SQLSTATE) sqlstate

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -1515,7 +1515,8 @@ void convert_to_zval( _Inout_ sqlsrv_stmt* stmt, _In_ SQLSRV_PHPTYPE sqlsrv_php_
 	}
 	case SQLSRV_PHPTYPE_DATETIME:
 	{
-		out_zval = *( static_cast<zval*>( in_val ));
+		//out_zval = *( static_cast<zval*>( in_val ));
+        convert_datetime_string_to_zval(stmt, reinterpret_cast<char*>(in_val), field_len, out_zval);
 		break;
 	}
 

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -1515,8 +1515,7 @@ void convert_to_zval( _Inout_ sqlsrv_stmt* stmt, _In_ SQLSRV_PHPTYPE sqlsrv_php_
 	}
 	case SQLSRV_PHPTYPE_DATETIME:
 	{
-		//out_zval = *( static_cast<zval*>( in_val ));
-        convert_datetime_string_to_zval(stmt, reinterpret_cast<char*>(in_val), field_len, out_zval);
+        convert_datetime_string_to_zval(stmt, static_cast<char*>(in_val), field_len, out_zval);
 		break;
 	}
 

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -1513,11 +1513,11 @@ void convert_to_zval( _Inout_ sqlsrv_stmt* stmt, _In_ SQLSRV_PHPTYPE sqlsrv_php_
 		Z_TRY_ADDREF( out_zval );
 		break;
 	}
-	case SQLSRV_PHPTYPE_DATETIME:
-	{
+    case SQLSRV_PHPTYPE_DATETIME:
+    {
         convert_datetime_string_to_zval(stmt, static_cast<char*>(in_val), field_len, out_zval);
-		break;
-	}
+        break;
+    }
 
 	case SQLSRV_PHPTYPE_NULL:
 		ZVAL_NULL(&out_zval);

--- a/test/functional/pdo_sqlsrv/pdo_fetch_datetime_time_nulls.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_fetch_datetime_time_nulls.phpt
@@ -110,7 +110,6 @@ function runTest($conn, $query, $columns, $useBuffer = false)
     // last test: set statement attribute fetch_datetime on with no change to 
     // prepared statement -- expected datetime objects to be returned
     $stmt->setAttribute(PDO::SQLSRV_ATTR_FETCHES_DATETIME_TYPE, true);
-    $stmt->execute();
     $i = 0;
     do {
         $stmt->execute();


### PR DESCRIPTION
No need to convert a datetime string to a DateTime object until it is required to be returned as zval. For caching only datetime strings are needed.