### PR TITLE
Fixed the skipif wordings and styles

### DIFF
--- a/Dockerfile-msphpsql
+++ b/Dockerfile-msphpsql
@@ -21,6 +21,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
     make \
     php7.3 \
     php7.3-dev \
+    php7.3-intl \
     python-pip \
     re2c \
     unixodbc-dev \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,7 @@ jobs:
 
   - script: |
       echo ready to build extensions
+      sudo apt-get install -y php$(phpVersion)-intl
       cd $(Build.SourcesDirectory)/source
       chmod a+x packagize.sh
       ./packagize.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,8 @@ jobs:
     displayName: 'Build and install drivers'
 
 - job: Linux
+  variables:
+    phpver: 7.3
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
@@ -72,13 +74,13 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      sudo update-alternatives --set php /usr/bin/php$(phpVersion)
-      sudo update-alternatives --set phar /usr/bin/phar$(phpVersion)
-      sudo update-alternatives --set phpdbg /usr/bin/phpdbg$(phpVersion)
-      sudo update-alternatives --set php-cgi /usr/bin/php-cgi$(phpVersion)
-      sudo update-alternatives --set phar.phar /usr/bin/phar.phar$(phpVersion)
+      sudo update-alternatives --set php /usr/bin/php$(phpver)
+      sudo update-alternatives --set phar /usr/bin/phar$(phpver)
+      sudo update-alternatives --set phpdbg /usr/bin/phpdbg$(phpver)
+      sudo update-alternatives --set php-cgi /usr/bin/php-cgi$(phpver)
+      sudo update-alternatives --set phar.phar /usr/bin/phar.phar$(phpver)
       php -version
-    displayName: 'Use PHP version $(phpVersion)'
+    displayName: 'Use PHP version $(phpver)'
 
   - script: |
       echo install ODBC and dependencies
@@ -128,7 +130,7 @@ jobs:
 
   - script: |
       echo ready to build extensions
-      sudo apt-get install -y php$(phpVersion)-intl
+      sudo apt-get install -y php$(phpver)-intl
       cd $(Build.SourcesDirectory)/source
       chmod a+x packagize.sh
       ./packagize.sh

--- a/test/functional/pdo_sqlsrv/pdo_1063_locale_configs.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_1063_locale_configs.phpt
@@ -46,7 +46,7 @@ Current LC_CTYPE: en_US.UTF-8
 Setting LC_ALL: en_US.ISO-8859-1
 Currency symbol: $
 Thousands_sep: ,
-Amount formatted: USD 10,000.99
+Amount formatted: $10,000.99
 Friday
 December
 3.14159
@@ -71,7 +71,7 @@ Current LC_CTYPE: en_US.UTF-8
 Setting LC_ALL: de_DE.UTF-8
 Currency symbol: €
 Thousands_sep: .
-Amount formatted: 10.000,99 EUR
+Amount formatted: 10.000,99 €
 Freitag
 Dezember
 3,14159
@@ -85,7 +85,7 @@ Current LC_MONETARY: en_US.UTF-8
 Current LC_CTYPE: en_US.UTF-8
 Currency symbol: $
 Thousands_sep: ,
-Amount formatted: USD 10,000.99
+Amount formatted: $10,000.99
 Friday
 December
 3.14159
@@ -96,7 +96,7 @@ Current LC_CTYPE: en_US.UTF-8
 Setting LC_ALL: de_DE.UTF-8
 Currency symbol: €
 Thousands_sep: .
-Amount formatted: 10.000,99 EUR
+Amount formatted: 10.000,99 €
 Freitag
 Dezember
 3,14159

--- a/test/functional/pdo_sqlsrv/pdo_1063_test_locale.php
+++ b/test/functional/pdo_sqlsrv/pdo_1063_test_locale.php
@@ -6,6 +6,27 @@ function dropTable($conn, $tableName)
     $conn->exec($tsql);
 }
 
+function printMoney($amt) 
+{
+    // The money_format() function is deprecated in PHP 7.4, so use intl NumberFormatter
+    $info = localeconv();
+    echo "Currency symbol: " . $info['currency_symbol'] . PHP_EOL;
+    echo "Thousands_sep: " . $info['thousands_sep'] . PHP_EOL;
+
+    $loc = setlocale(LC_MONETARY, 0);
+    $symbol = $info['int_curr_symbol'];
+
+    echo "Amount formatted: ";
+    if (empty($symbol)) {
+        echo number_format($amt, 2, '.', '');
+    } else {
+        $fmt = new NumberFormatter($loc, NumberFormatter::CURRENCY);
+        $fmt->setTextAttribute(NumberFormatter::CURRENCY_CODE, $symbol);
+        $fmt->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+        echo $fmt->format($amt);
+    }
+    echo PHP_EOL;
+}
 
 // This test is invoked by pdo_1063_locale_configs.phpt
 require_once('MsSetup.inc');
@@ -21,12 +42,9 @@ if (!empty($locale)) {
     echo "Setting LC_ALL: " . $loc . PHP_EOL;
 }
 
-$info = localeconv();
-echo "Currency symbol: " . $info['currency_symbol'] . PHP_EOL;
-echo "Thousands_sep: " . $info['thousands_sep'] . PHP_EOL;
-
 $n1 = 10000.98765;
-echo "Amount formatted: " . money_format("%i", $n1) . PHP_EOL;
+printMoney($n1);
+
 echo strftime("%A", strtotime("12/25/2020")) . PHP_EOL;
 echo strftime("%B", strtotime("12/25/2020")) . PHP_EOL;
 

--- a/test/functional/pdo_sqlsrv/skipif.inc
+++ b/test/functional/pdo_sqlsrv/skipif.inc
@@ -1,4 +1,4 @@
 <?php
-if (!extension_loaded("pdo") || !extension_loaded('pdo_sqlsrv'))
-    die("PDO driver cannot be loaded; skipping test.\n");
-?>
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
+}

--- a/test/functional/pdo_sqlsrv/skipif_azure.inc
+++ b/test/functional/pdo_sqlsrv/skipif_azure.inc
@@ -1,8 +1,8 @@
 <?php
-if (!extension_loaded("pdo") || !extension_loaded('pdo_sqlsrv'))
-    die("PDO driver cannot be loaded; skipping test.\n");
-    
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
+}
 require 'MsSetup.inc';
-if ($daasMode) die("skip test not applicable in Azure\n");
-   
-?>
+if ($daasMode) {
+    die("skip test not applicable in Azure\n");
+}

--- a/test/functional/pdo_sqlsrv/skipif_mid-refactor.inc
+++ b/test/functional/pdo_sqlsrv/skipif_mid-refactor.inc
@@ -1,6 +1,6 @@
 <?php
-if (!extension_loaded("pdo") || !extension_loaded('pdo_sqlsrv')) {
-    die("PDO driver cannot be loaded; skipping test.\n");
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
 }
 
 require_once("MsSetup.inc");
@@ -9,7 +9,7 @@ require_once("MsCommon_mid-refactor.inc");
 $dsn = getDSN($server, null);
 $conn = new PDO($dsn, $uid, $pwd);
 if (! $conn) {
-    echo("Error: could not connect during SKIPIF!");
+    die("skip could not connect during SKIPIF!");
 } elseif (isColEncrypted()) {
     if (!isAEQualified($conn)) {
         die("skip - AE feature not supported in the current environment.");

--- a/test/functional/pdo_sqlsrv/skipif_not_akv.inc
+++ b/test/functional/pdo_sqlsrv/skipif_not_akv.inc
@@ -1,16 +1,17 @@
 <?php
-if (!extension_loaded("pdo") || !extension_loaded('pdo_sqlsrv')) {
-    die("PDO driver cannot be loaded; skipping test.\n");
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
 }
 
 require_once("MsSetup.inc");
 
-if ($keystore != 'akv')
-    die ( 'skip - the test requires valid Azure Key Vault credentials.' );
+if ($keystore != 'akv') {
+    die('skip the test requires valid Azure Key Vault credentials.');
+}
     
 if ($driver != "ODBC Driver 17 for SQL Server") {
     // the testing is not set to use ODBC 17
-    die("skip - AE feature not supported in the current environment.");
+    die("skip AE feature not supported in the current environment.");
 }
 
 require_once("MsCommon_mid-refactor.inc");
@@ -18,7 +19,7 @@ require_once("MsCommon_mid-refactor.inc");
 $dsn = getDSN($server, null);
 $conn = new PDO($dsn, $uid, $pwd);
 if (! $conn) {
-    echo("Error: could not connect during SKIPIF!");
+    die("skip could not connect during SKIPIF!");
 } elseif (!isAEQualified($conn)) {
-    die("skip - AE feature not supported in the current environment.");
+    die("skip AE feature not supported in the current environment.");
 }

--- a/test/functional/pdo_sqlsrv/skipif_unix.inc
+++ b/test/functional/pdo_sqlsrv/skipif_unix.inc
@@ -1,8 +1,9 @@
 <?php
 
-if ( !( strtoupper( substr( php_uname( 's' ),0,3 ) ) === 'WIN' ) ) die( "Skip, test on windows only." ); 
+if (!(strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN')) {
+    die("Skip test on windows only.");
+}
 
-if (!extension_loaded("pdo") || !extension_loaded('pdo_sqlsrv'))
-    die("PDO driver cannot be loaded; skipping test.\n");
-
-?>
+if (!extension_loaded("pdo") || !extension_loaded('pdo_sqlsrv')) {
+    die("skip extension not loaded");
+}

--- a/test/functional/pdo_sqlsrv/skipif_unix_locales.inc
+++ b/test/functional/pdo_sqlsrv/skipif_unix_locales.inc
@@ -1,29 +1,28 @@
 <?php
 
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-    die("Skipped: Test for Linux and macOS");
+    die("skip Test for Linux and macOS");
 }
 
-if (!extension_loaded("sqlsrv")) {
-    die("skip extension not loaded");
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
 }
 
 // check if the required ini file exists
 $inifile = PHP_CONFIG_FILE_SCAN_DIR."/99-overrides.ini";
 if (!file_exists($inifile)) {
-    die("required ini file not exists");
+    die("skip required ini file not exists");
 }
 
 // if the file exists, is it writable? '@' sign is used to suppress warnings
 $file = @fopen($inifile, "w");
 if (!$file) {
-    die("required ini file not writable");
+    die("skip required ini file not writable");
 }
 
 fclose($file);
 
 $loc = setlocale(LC_TIME, 'de_DE.UTF-8');
 if (empty($loc)) {
-    die("required locale not available");
+    die("skip required locale not available");
 }
-?>

--- a/test/functional/pdo_sqlsrv/skipif_versions_old.inc
+++ b/test/functional/pdo_sqlsrv/skipif_versions_old.inc
@@ -1,18 +1,15 @@
 <?php
 
-if (! extension_loaded( 'pdo' ) || ! extension_loaded( 'pdo_sqlsrv' ))
-    die( "PDO driver cannot be loaded; skipping test.\n" );
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
+}
 
-require_once( "MsSetup.inc" );
-require_once( "MsCommon.inc" );
+require_once("MsSetup.inc");
+require_once("MsCommon.inc");
 
 $conn = ae_connect();
-if( ! $conn )
-{
-    echo( "Error: could not connect during SKIPIF!" );
+if (! $conn) {
+    die("skip could not connect during SKIPIF!");
+} elseif (! IsAEQualified($conn)) {
+    die("skip AE feature not supported in the current environment.");
 }
-else if(! IsAEQualified($conn))
-{
-    die( "skip - AE feature not supported in the current environment." );
-}
-?>

--- a/test/functional/sqlsrv/skipif_not_akv.inc
+++ b/test/functional/sqlsrv/skipif_not_akv.inc
@@ -5,20 +5,20 @@ if (! extension_loaded("sqlsrv")) {
 }
 
 require_once("MsSetup.inc");
-if ($keystore != 'akv')
-    die ( 'skip - the test requires valid Azure Key Vault credentials.' );
+if ($keystore != 'akv') {
+    die('skip the test requires valid Azure Key Vault credentials.');
+}
 
 if ($driver != "ODBC Driver 17 for SQL Server") {
     // the testing is not set to use ODBC 17
-    die("skip - AE feature not supported in the current environment.");
+    die("skip AE feature not supported in the current environment.");
 }
 
 require_once('MsCommon.inc');
 
 $conn = AE\connect();
 if (! $conn) {
-    echo("Error: could not connect during SKIPIF!");
+    die("skip could not connect during SKIPIF!");
 } elseif (!AE\isQualified($conn)) {
-    die("skip - AE feature not supported in the current environment.");
+    die("skip AE feature not supported in the current environment.");
 }
-?>

--- a/test/functional/sqlsrv/skipif_unix.inc
+++ b/test/functional/sqlsrv/skipif_unix.inc
@@ -1,9 +1,9 @@
 <?php
 
-if ( !( strtoupper( substr( php_uname( 's' ),0,3 ) ) === 'WIN' ) ) die( "Skip, test on windows only." ); 
+if (!(strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN')) {
+    die("Skip Test on windows only.");
+}
 
 if (!extension_loaded("sqlsrv")) {
     die("skip extension not loaded");
 }
-
-?>

--- a/test/functional/sqlsrv/skipif_unix_locales.inc
+++ b/test/functional/sqlsrv/skipif_unix_locales.inc
@@ -1,7 +1,7 @@
 <?php
 
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-    die("Skipped: Test for Linux and macOS");
+    die("skip: Test for Linux and macOS");
 }
 
 if (!extension_loaded("sqlsrv")) {
@@ -11,19 +11,18 @@ if (!extension_loaded("sqlsrv")) {
 // check if the required ini file exists
 $inifile = PHP_CONFIG_FILE_SCAN_DIR."/99-overrides.ini";
 if (!file_exists($inifile)) {
-    die("required ini file not exists");
+    die("skip required ini file not exists");
 }
 
 // if the file exists, is it writable? '@' sign is used to suppress warnings
 $file = @fopen($inifile, "w");
 if (!$file) {
-    die("required ini file not writable");
+    die("skip required ini file not writable");
 }
 
 fclose($file);
 
 $loc = setlocale(LC_TIME, 'de_DE.UTF-8');
 if (empty($loc)) {
-    die("required locale not available");
+    die("skip required locale not available");
 }
-?>

--- a/test/functional/sqlsrv/skipif_versions_old.inc
+++ b/test/functional/sqlsrv/skipif_versions_old.inc
@@ -8,10 +8,9 @@ require_once('MsCommon.inc');
 
 $conn = AE\connect();
 if (! $conn) {
-    echo("Error: could not connect during SKIPIF!");
+    die("Skip Could not connect during SKIPIF!");
 } elseif (AE\isColEncrypted()) {
     if (!AE\isQualified($conn)) {
-        die("skip - AE feature not supported in the current environment.");
+        die("skip AE feature not supported in the current environment.");
     }
 }
-?>

--- a/test/functional/sqlsrv/srv_1063_locale_configs.phpt
+++ b/test/functional/sqlsrv/srv_1063_locale_configs.phpt
@@ -46,7 +46,7 @@ Current LC_CTYPE: en_US.UTF-8
 Setting LC_ALL: en_US.ISO-8859-1
 Currency symbol: $
 Thousands_sep: ,
-Amount formatted: USD 10,000.99
+Amount formatted: $10,000.99
 Friday
 December
 3.14159
@@ -71,7 +71,7 @@ Current LC_CTYPE: en_US.UTF-8
 Setting LC_ALL: de_DE.UTF-8
 Currency symbol: €
 Thousands_sep: .
-Amount formatted: 10.000,99 EUR
+Amount formatted: 10.000,99 €
 Freitag
 Dezember
 3,14159
@@ -85,7 +85,7 @@ Current LC_MONETARY: en_US.UTF-8
 Current LC_CTYPE: en_US.UTF-8
 Currency symbol: $
 Thousands_sep: ,
-Amount formatted: USD 10,000.99
+Amount formatted: $10,000.99
 Friday
 December
 3.14159
@@ -96,7 +96,7 @@ Current LC_CTYPE: en_US.UTF-8
 Setting LC_ALL: de_DE.UTF-8
 Currency symbol: €
 Thousands_sep: .
-Amount formatted: 10.000,99 EUR
+Amount formatted: 10.000,99 €
 Freitag
 Dezember
 3,14159

--- a/test/functional/sqlsrv/srv_1063_test_locale.php
+++ b/test/functional/sqlsrv/srv_1063_test_locale.php
@@ -12,6 +12,28 @@ function fatalError($message)
     die($message);
 }
 
+function printMoney($amt) 
+{
+    // The money_format() function is deprecated in PHP 7.4, so use intl NumberFormatter
+    $info = localeconv();
+    echo "Currency symbol: " . $info['currency_symbol'] . PHP_EOL;
+    echo "Thousands_sep: " . $info['thousands_sep'] . PHP_EOL;
+
+    $loc = setlocale(LC_MONETARY, 0);
+    $symbol = $info['int_curr_symbol'];
+
+    echo "Amount formatted: ";
+    if (empty($symbol)) {
+        echo number_format($amt, 2, '.', '');
+    } else {
+        $fmt = new NumberFormatter($loc, NumberFormatter::CURRENCY);
+        $fmt->setTextAttribute(NumberFormatter::CURRENCY_CODE, $symbol);
+        $fmt->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
+        echo $fmt->format($amt);
+    }
+    echo PHP_EOL;
+}
+
 // This test is invoked by srv_1063_locale_configs.phpt
 require_once('MsSetup.inc');
 
@@ -26,12 +48,9 @@ if (!empty($locale)) {
     echo "Setting LC_ALL: " . $loc . PHP_EOL;
 }
 
-$info = localeconv();
-echo "Currency symbol: " . $info['currency_symbol'] . PHP_EOL;
-echo "Thousands_sep: " . $info['thousands_sep'] . PHP_EOL;
-
 $n1 = 10000.98765;
-echo "Amount formatted: " . money_format("%i", $n1) . PHP_EOL;
+printMoney($n1);
+
 echo strftime("%A", strtotime("12/25/2020")) . PHP_EOL;
 echo strftime("%B", strtotime("12/25/2020")) . PHP_EOL;
 


### PR DESCRIPTION
The money_format() function is deprecated in PHP 7.4, so use intl NumberFormatter
