### PR TITLE
Added codecov yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Azure Pipelines       | AppVeyor (Windows)       | Travis CI (Linux)        | Co
 [az-image]: https://dev.azure.com/sqlclientdrivers-ci/msphpsql/_apis/build/status/Microsoft.msphpsql?branchName=dev
 [Coverage Coveralls]: https://coveralls.io/repos/github/microsoft/msphpsql/badge.svg?branch=dev
 [coveralls-site]: https://coveralls.io/github/microsoft/msphpsql?branch=dev
-[Coverage Codecov]: https://codecov.io/gh/microsoft/msphpsql/branch/master/graph/badge.svg
+[Coverage Codecov]: https://codecov.io/gh/microsoft/msphpsql/branch/dev/graph/badge.svg
 [codecov-site]: https://codecov.io/gh/microsoft/msphpsql
 
 ## Get Started

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  require_ci_to_pass: yes
+  max_report_age: off
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Codecov will reject reports that are over 12 hours old according to the timestamp in the report. To disable this functionality add `max_report_age: off` to the repo codecov.yml.