### PR TITLE
Updated skipifs and modified tests with HGS enabled servers

### DIFF
--- a/test/functional/pdo_sqlsrv/pdo_connect_encrypted.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_connect_encrypted.phpt
@@ -89,7 +89,6 @@ function testColumnEncryption($server, $uid, $pwd, $msodbcsqlMaj)
     try {
         $conn = new PDO("sqlsrv:server = $server ; $connectionInfo", $uid, $pwd);
     } catch (PDOException $e) {
-        // $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
         verifyOutput($e, $expected, "3");
     }
 
@@ -99,7 +98,6 @@ function testColumnEncryption($server, $uid, $pwd, $msodbcsqlMaj)
     try {
         $conn = new PDO("sqlsrv:server = $server ; $connectionInfo", $uid, $pwd);
     } catch (PDOException $e) {
-        // $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
         verifyOutput($e, $expected, "4");
     }
 }

--- a/test/functional/pdo_sqlsrv/pdo_connect_encrypted.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_connect_encrypted.phpt
@@ -1,57 +1,63 @@
 --TEST--
 Test new connection keyword ColumnEncryption
+--DESCRIPTION--
+Some test cases return errors as expected. For testing purposes, an enclave enabled 
+SQL Server and the HGS server are the same instance. If the server is HGS enabled,
+the error message of one test case is not the same.
 --SKIPIF--
 <?php require('skipif_mid-refactor.inc'); ?>
 --FILE--
 <?php
 require_once("MsSetup.inc");
-$msodbcsql_maj = "";
+$msodbcsqlMaj = "";
+$hgsEnabled = true;
 
-try
-{
-    $conn = new PDO( "sqlsrv:server = $server", $uid, $pwd );
-    $msodbcsql_ver = $conn->getAttribute( PDO::ATTR_CLIENT_VERSION )['DriverVer'];
-    $msodbcsql_maj = explode(".", $msodbcsql_ver)[0];
-}
-catch( PDOException $e )
-{
+try {
+    $conn = new PDO("sqlsrv:server = $server", $uid, $pwd);
+    $msodbcsqlVer = $conn->getAttribute(PDO::ATTR_CLIENT_VERSION)['DriverVer'];
+    $version = explode(".", $msodbcsqlVer);
+    $msodbcsqlMaj = $version[0];
+
+    // Next, check if the server is HGS enabled
+    $serverInfo = $conn->getAttribute(PDO::ATTR_SERVER_INFO);
+    if (strpos($serverInfo['SQLServerName'], 'PHPHGS') === false) {
+        $hgsEnabled = false;
+    }
+} catch (PDOException $e) {
     echo "Failed to connect\n";
-    print_r( $e->getMessage() );
+    print_r($e->getMessage());
     echo "\n";
 }
 
-test_ColumnEncryption( $server, $uid, $pwd, $msodbcsql_maj );
+testColumnEncryption($server, $uid, $pwd, $msodbcsqlMaj);
 echo "Done";
 
 
-function verify_output( $PDOerror, $expected )
+function verifyOutput($PDOerror, $expected, $caseNum)
 {
-    if( strpos( $PDOerror->getMessage(), $expected ) === false )
-    {
-        print_r( $PDOerror->getMessage() );
+    if (strpos($PDOerror->getMessage(), $expected) === false) {
+        echo "Test case $caseNum failed:\n";
+        print_r($PDOerror->getMessage());
         echo "\n";
     }
 }
 
-function test_ColumnEncryption( $server, $uid, $pwd, $msodbcsql_maj )
+function testColumnEncryption($server, $uid, $pwd, $msodbcsqlMaj)
 {
+    global $hgsEnabled;
+    
     // Only works for ODBC 17
     ////////////////////////////////////////
     $connectionInfo = "ColumnEncryption = Enabled;";
-    try
-    {
-        $conn = new PDO( "sqlsrv:server = $server ; $connectionInfo", $uid, $pwd );
-    }
-    catch( PDOException $e )
-    {
-        if($msodbcsql_maj < 17)
-        {
+    try {
+        $conn = new PDO("sqlsrv:server = $server ; $connectionInfo", $uid, $pwd);
+    } catch (PDOException $e) {
+        if ($msodbcsqlMaj < 17) {
             $expected = "The Always Encrypted feature requires Microsoft ODBC Driver 17 for SQL Server.";
-            verify_output( $e, $expected );
-        }
-        else
-        {
-            print_r( $e->getMessage() );
+            verifyOutput($e, $expected, "1");
+        } else {
+            echo "Test case 1 failed:\n";
+            print_r($e->getMessage());
             echo "\n";
         }
     }
@@ -59,50 +65,44 @@ function test_ColumnEncryption( $server, $uid, $pwd, $msodbcsql_maj )
     // Works for ODBC 17, ODBC 13
     ////////////////////////////////////////
     $connectionInfo = "ColumnEncryption = Disabled;";
-    try
-    {
-        $conn = new PDO( "sqlsrv:server = $server ; $connectionInfo", $uid, $pwd );
-    }
-    catch( PDOException $e )
-    {
-        if($msodbcsql_maj < 13)
-        {
+    try {
+        $conn = new PDO("sqlsrv:server = $server ; $connectionInfo", $uid, $pwd);
+    } catch (PDOException $e) {
+        if ($msodbcsqlMaj < 13) {
             $expected = "Invalid connection string attribute";
-            verify_output( $e, $expected );
-        }
-        else
-        {
-            print_r( $e->getMessage() );
+            verifyOutput($e, $expected, "2");
+        } else {
+            echo "Test case 2 failed:\n";
+            print_r($e->getMessage());
             echo "\n";
         }
     }
 
     // should fail for all ODBC drivers
+    $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
+    if ($hgsEnabled) {
+        $expected = "Requested attestation protocol is invalid.";
+    }
+    
     ////////////////////////////////////////
     $connectionInfo = "ColumnEncryption = false;";
-    try
-    {
-        $conn = new PDO( "sqlsrv:server = $server ; $connectionInfo", $uid, $pwd );
-    }
-    catch( PDOException $e )
-    {
-        $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
-        verify_output( $e, $expected );   
+    try {
+        $conn = new PDO("sqlsrv:server = $server ; $connectionInfo", $uid, $pwd);
+    } catch (PDOException $e) {
+        // $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
+        verifyOutput($e, $expected, "3");
     }
 
     // should fail for all ODBC drivers
     ////////////////////////////////////////
     $connectionInfo = "ColumnEncryption = 1;";
-    try
-    {
-        $conn = new PDO( "sqlsrv:server = $server ; $connectionInfo", $uid, $pwd );
+    try {
+        $conn = new PDO("sqlsrv:server = $server ; $connectionInfo", $uid, $pwd);
+    } catch (PDOException $e) {
+        // $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
+        verifyOutput($e, $expected, "4");
     }
-    catch( PDOException $e )
-    {
-        $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
-        verify_output( $e, $expected );
-    }	
-}     
+}
 ?>
 --EXPECT--
 Done

--- a/test/functional/pdo_sqlsrv/skipif_not_hgs.inc
+++ b/test/functional/pdo_sqlsrv/skipif_not_hgs.inc
@@ -3,34 +3,34 @@
 // SQL Server, and a HGS server. The HGS server and SQL Server
 // are the same for testing purposes.
 
-if (!extension_loaded("sqlsrv")) {
+if (!extension_loaded("pdo_sqlsrv")) {
     die("skip Extension not loaded");
 }
 
-require_once("MsSetup.inc");
+require_once('MsSetup.inc');
 
-$connectionInfo = array("UID"=>$uid, "PWD"=>$pwd, "Driver" => $driver);
-
-$conn = sqlsrv_connect( $server, $connectionInfo );
-if ($conn === false) {
-    die( "skip Could not connect during SKIPIF." );
+$conn = new PDO("sqlsrv:server = $server", $uid, $pwd);
+if (!$conn) {
+    die("skip Could not connect during SKIPIF.");
 }
 
-$msodbcsql_ver = sqlsrv_client_info($conn)["DriverVer"];
-$msodbcsql_maj = explode(".", $msodbcsql_ver)[0];
-$msodbcsql_min = explode(".", $msodbcsql_ver)[1];
+$msodbcsqlVer = $conn->getAttribute(PDO::ATTR_CLIENT_VERSION)['DriverVer'];
+$version = explode(".", $msodbcsqlVer);
 
-if ($msodbcsql_maj < 17) {
+$msodbcsqlMaj = $version[0];
+$msodbcsqlMin = $version[1];
+
+if ($msodbcsqlMaj < 17) {
     die("skip Unsupported ODBC driver version");
 }
 
-if ($msodbcsql_min < 4 and $msodbcsql_maj == 17) {
+if ($msodbcsqlMin < 4 and $msodbcsqlMaj == 17) {
     die("skip Unsupported ODBC driver version");
 }
 
 // Get SQL Server
-$server_info = sqlsrv_server_info($conn);
-if (strpos($server_info['SQLServerName'], 'PHPHGS') === false) {
+$serverInfo = $conn->getAttribute(PDO::ATTR_SERVER_INFO);
+if (strpos($serverInfo['SQLServerName'], 'PHPHGS') === false) {
     die("skip Server is not HGS enabled");
 }
 ?>

--- a/test/functional/sqlsrv/skipif_not_hgs.inc
+++ b/test/functional/sqlsrv/skipif_not_hgs.inc
@@ -9,11 +9,11 @@ if (!extension_loaded("sqlsrv")) {
 
 require_once("MsSetup.inc");
 
-$connectionInfo = array("UID"=>$userName, "PWD"=>$userPassword, "Driver" => $driver);
+$connectionInfo = array("UID"=>$userName, "PWD"=>$userPassword);
 
-$conn = sqlsrv_connect( $server, $connectionInfo );
+$conn = sqlsrv_connect($server, $connectionInfo);
 if ($conn === false) {
-    die( "skip Could not connect during SKIPIF." );
+    die("skip Could not connect during SKIPIF.");
 }
 
 $msodbcsql_ver = sqlsrv_client_info($conn)["DriverVer"];

--- a/test/functional/sqlsrv/sqlsrv_connect_encrypted.phpt
+++ b/test/functional/sqlsrv/sqlsrv_connect_encrypted.phpt
@@ -1,98 +1,101 @@
 --TEST--
-Test new connection keyword ColumnEncryption
+Test new connection keyword ColumnEncryption with different input values
+--DESCRIPTION--
+Some test cases return errors as expected. For testing purposes, an enclave enabled 
+SQL Server and the HGS server are the same instance. If the server is HGS enabled,
+the error message of one test case is not the same.
 --SKIPIF--
 <?php require('skipif.inc'); ?>
 --FILE--
 <?php
-sqlsrv_configure( 'WarningsReturnAsErrors', 0 );
-require( 'MsSetup.inc' );
+sqlsrv_configure('WarningsReturnAsErrors', 0);
+require('MsSetup.inc');
 
 $connectionOptions = array("Database"=>$database,"UID"=>$userName, "PWD"=>$userPassword);
-test_ColumnEncryption($server, $connectionOptions);
+testColumnEncryption($server, $connectionOptions);
 echo "Done";
 
-function test_ColumnEncryption($server ,$connectionOptions){
+function testColumnEncryption($server, $connectionOptions)
+{
     $conn = sqlsrv_connect($server, $connectionOptions);
-    if ($conn === false)
-    {
+    if ($conn === false) {
         print_r(sqlsrv_errors());
     }
     $msodbcsql_ver = sqlsrv_client_info($conn)['DriverVer'];
-    $msodbcsql_maj = explode(".", $msodbcsql_ver)[0];
+    $msodbcsqlMaj = explode(".", $msodbcsql_ver)[0];
 
+    // Next, check if the server is HGS enabled
+    $hgsEnabled = true;
+    $serverInfo = sqlsrv_server_info($conn);
+    if (strpos($serverInfo['SQLServerName'], 'PHPHGS') === false) {
+        $hgsEnabled = false;
+    }
+    
     // Only works for ODBC 17
-    $connectionOptions['ColumnEncryption']='Enabled';
-    $conn = sqlsrv_connect( $server, $connectionOptions );
-    if( $conn === false )
-    {
-        if($msodbcsql_maj < 17){
+    $connectionOptions['ColumnEncryption'] = 'Enabled';
+    $conn = sqlsrv_connect($server, $connectionOptions);
+    if ($conn === false) {
+        if ($msodbcsqlMaj < 17) {
             $expected = "The Always Encrypted feature requires Microsoft ODBC Driver 17 for SQL Server.";
-            if( strcasecmp(sqlsrv_errors($conn)[0]['message'], $expected ) != 0 )
-            {
+            if (strcasecmp(sqlsrv_errors($conn)[0]['message'], $expected) != 0) {
                 print_r(sqlsrv_errors());
             }
-        }
-        else
-        {
+        } else {
+            echo "Test case 1 failed:\n";
             print_r(sqlsrv_errors());
         }
     }
-    
+
     // Works for ODBC 17, ODBC 13
     $connectionOptions['ColumnEncryption']='Disabled';
-    $conn = sqlsrv_connect( $server, $connectionOptions );
-    if( $conn === false )
-    {
-        if($msodbcsql_maj < 13)
-        {
-            $expected_substr = "Invalid connection string attribute";
-            if( strpos(sqlsrv_errors($conn)[0]['message'], $expected_substr ) === false )
-            {
+    $conn = sqlsrv_connect($server, $connectionOptions);
+    if ($conn === false) {
+        if ($msodbcsqlMaj < 13) {
+            $expected = "Invalid connection string attribute";
+            if (strpos(sqlsrv_errors($conn)[0]['message'], $expected) === false) {
                 print_r(sqlsrv_errors());
             }
-        }
-        else
-        {
+        } else {
+            echo "Test case 2 failed:\n";
             print_r(sqlsrv_errors());
         }
-    }
-    else
-    {
+    } else {
         sqlsrv_close($conn);
     }
+
+    // Should fail for all ODBC drivers - but the error message returned depends on the server
+    $expected = "Invalid value specified for connection string attribute 'ColumnEncryption'";
+    if ($hgsEnabled) {
+        $expected = "Requested attestation protocol is invalid.";
+    }
     
-    // should fail for all ODBC drivers
     $connectionOptions['ColumnEncryption']='false';
-    $conn = sqlsrv_connect( $server, $connectionOptions );
-    if( $conn === false )
-    {
-        $expected_substr = "Invalid value specified for connection string attribute 'ColumnEncryption'";
-        if( strpos(sqlsrv_errors($conn)[0]['message'], $expected_substr ) === false )
-        {
+    $conn = sqlsrv_connect($server, $connectionOptions);
+    if ($conn === false) {
+        if (strpos(sqlsrv_errors($conn)[0]['message'], $expected) === false) {
+            echo "Test case 3 failed:\n";
             print_r(sqlsrv_errors());
         }
     }
     
-    // should fail for all ODBC drivers
+    $expected = "Invalid value type for option ColumnEncryption was specified.  String type was expected.";
+
+    // should fail for all ODBC drivers with the above error message
     $connectionOptions['ColumnEncryption']=true;
-    $conn = sqlsrv_connect( $server, $connectionOptions );
-    if( $conn === false )
-    {
-        $expected_substr = "Invalid value type for option ColumnEncryption was specified.  String type was expected.";
-        if( strpos(sqlsrv_errors($conn)[0]['message'], $expected_substr ) === false )
-        {
+    $conn = sqlsrv_connect($server, $connectionOptions);
+    if ($conn === false) {
+        if (strpos(sqlsrv_errors($conn)[0]['message'], $expected) === false) {
+            echo "Test case 4 failed:\n";
             print_r(sqlsrv_errors());
         }
     }
     
-    // should fail for all ODBC drivers
+    // should fail for all ODBC drivers with the above error message
     $connectionOptions['ColumnEncryption']=false;
-    $conn = sqlsrv_connect( $server, $connectionOptions );
-    if( $conn === false )
-    {
-       $expected_substr = "Invalid value type for option ColumnEncryption was specified.  String type was expected.";
-        if( strpos(sqlsrv_errors($conn)[0]['message'], $expected_substr ) === false )
-        {
+    $conn = sqlsrv_connect($server, $connectionOptions);
+    if ($conn === false) {
+        if (strpos(sqlsrv_errors($conn)[0]['message'], $expected) === false) {
+            echo "Test case 5 failed:\n";
             print_r(sqlsrv_errors());
         }
     }


### PR DESCRIPTION
In SKIPIF should not specify ODBC driver and then check if ODBC 17 is used.
Also fixed the coding style to adhere to the PSR-2 standard