### PR TITLE
Binding integers as output parameters with correct C types

### DIFF
--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -2079,13 +2079,14 @@ SQLSMALLINT default_c_type( _Inout_ sqlsrv_stmt* stmt, _In_opt_ SQLULEN paramno,
             sql_c_type = SQL_C_SLONG;
             break;
         case IS_LONG:
-            //ODBC 64-bit long and integer type are 4 byte values.
-            if ((Z_LVAL_P(param_z) < INT_MIN) || (Z_LVAL_P(param_z) > INT_MAX)) {
-                sql_c_type = SQL_C_SBIGINT;
-            }
-            else {
-                sql_c_type = SQL_C_SLONG;
-            }
+            // When binding any integer, the zend_long value and its length are used as the buffer 
+            // and buffer length. When the buffer is 8 bytes use the corresponding C type for 
+            // 8-byte integers
+#ifdef ZEND_ENABLE_ZVAL_LONG64
+            sql_c_type = SQL_C_SBIGINT;
+#else
+            sql_c_type = SQL_C_SLONG;
+#endif
             break;
         case IS_DOUBLE:
             sql_c_type = SQL_C_DOUBLE;

--- a/test/functional/sqlsrv/srv_699_out_param_integer.phpt
+++ b/test/functional/sqlsrv/srv_699_out_param_integer.phpt
@@ -65,12 +65,30 @@ if (strtoupper(substr(PHP_OS, 0, 3)) === 'LIN') {
 
 $sql_callSP = $set_no_count . "{call $procName(?)}";
 
-// Initialize the output parameter to any number
+// Initialize the output parameter to any positive number
 $outParam = 1; 
 $params = array(array(&$outParam, SQLSRV_PARAM_OUT));
 $stmt = sqlsrv_query($conn, $sql_callSP, $params); 
 if (!$stmt) { 
     fatalError("Error in calling $procName\n"); 
+} 
+
+while ($res = sqlsrv_next_result($stmt)); 
+
+if ($outParam != 123) {
+    echo "The output param value $outParam is unexpected!\n";
+} 
+
+// Initialize the output parameter to any negative number
+$outParam = -1; 
+$params = array(array(&$outParam, SQLSRV_PARAM_OUT));
+$stmt = sqlsrv_prepare($conn, $sql_callSP, $params);
+if (!$stmt) { 
+    fatalError("Error in preparing $procName\n"); 
+} 
+$res = sqlsrv_execute($stmt);
+if (!$res) { 
+    fatalError("Error in executing $procName\n");
 } 
 
 while ($res = sqlsrv_next_result($stmt)); 


### PR DESCRIPTION
Related to #699 and #773 

When testing issue #699 , found that if the output param was initialized to -1, the result is a big negative value -4294967173, which is essentially FFFF FFFF 0000 007B (note that 7B is 123 -- the expected value). Because in a 64-bit system, a 8-byte buffer is supplied.

For details please check [C Data Types](https://docs.microsoft.com/sql/odbc/reference/appendixes/c-data-types?view=sql-server-ver15) 
