### PR TITLE
Simplied conversions from strings to numbers

### DIFF
--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -793,7 +793,6 @@ SQLRETURN sqlsrv_buffered_result_set::get_data( _In_ SQLUSMALLINT field_index, _
         case SQL_C_LONG: return sqlsrv_buffered_result_set::to_long(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_BINARY: return sqlsrv_buffered_result_set::to_long(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_CHAR: return sqlsrv_buffered_result_set::long_to_system_string(field_index, buffer, buffer_length, out_buffer_length);
-        //case SQL_C_WCHAR: return sqlsrv_buffered_result_set::long_to_wide_string(field_index, buffer, buffer_length, out_buffer_length);
         default:
             break;
         }
@@ -804,7 +803,6 @@ SQLRETURN sqlsrv_buffered_result_set::get_data( _In_ SQLUSMALLINT field_index, _
         case SQL_C_BINARY: return sqlsrv_buffered_result_set::to_double(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_CHAR: return sqlsrv_buffered_result_set::double_to_system_string(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_LONG: return sqlsrv_buffered_result_set::double_to_long(field_index, buffer, buffer_length, out_buffer_length);
-        //case SQL_C_WCHAR: return sqlsrv_buffered_result_set::double_to_wide_string(field_index, buffer, buffer_length, out_buffer_length);
         default:
             break;
         }
@@ -1024,24 +1022,6 @@ SQLRETURN sqlsrv_buffered_result_set::double_to_system_string( _In_ SQLSMALLINT 
     return r;
 }
 
-/*
-SQLRETURN sqlsrv_buffered_result_set::double_to_wide_string( _In_ SQLSMALLINT field_index, _Out_writes_bytes_to_opt_(buffer_length, *out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
-                                                             _Inout_ SQLLEN* out_buffer_length )
-{
-    SQLSRV_ASSERT( meta[field_index].c_type == SQL_C_DOUBLE, "Invalid conversion to wide string" );
-    SQLSRV_ASSERT( buffer_length > 0, "Buffer length must be > 0 in sqlsrv_buffered_result_set::double_to_wide_string" );
-
-    unsigned char* row = get_row();
-    double* double_data = reinterpret_cast<double*>( &row[meta[field_index].offset] );
-    SQLRETURN r = SQL_SUCCESS;
-#ifdef _WIN32
-    r = number_to_string<WCHAR>( double_data, buffer, buffer_length, out_buffer_length, last_error );
-#else
-    r = number_to_string<char16_t, double>( double_data, buffer, buffer_length, out_buffer_length, last_error );
-#endif // _WIN32
-    return r;
-}
-*/
 SQLRETURN sqlsrv_buffered_result_set::long_to_double( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length, 
                                                       _Out_ SQLLEN* out_buffer_length )
 {
@@ -1073,25 +1053,6 @@ SQLRETURN sqlsrv_buffered_result_set::long_to_system_string( _In_ SQLSMALLINT fi
 #endif // _WIN32
     return r;
 }
-
-/*
-SQLRETURN sqlsrv_buffered_result_set::long_to_wide_string( _In_ SQLSMALLINT field_index, _Out_writes_bytes_to_opt_(buffer_length, *out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
-                                                           _Inout_ SQLLEN* out_buffer_length )
-{
-    SQLSRV_ASSERT( meta[field_index].c_type == SQL_C_LONG, "Invalid conversion to wide string" );
-    SQLSRV_ASSERT( buffer_length > 0, "Buffer length must be > 0 in sqlsrv_buffered_result_set::long_to_wide_string" );
-
-    unsigned char* row = get_row();
-    LONG* long_data = reinterpret_cast<LONG*>( &row[meta[field_index].offset] );
-    SQLRETURN r = SQL_SUCCESS;
-#ifdef _WIN32
-    r = number_to_string<WCHAR>( long_data, buffer, buffer_length, out_buffer_length, last_error );
-#else
-    r = number_to_string<char16_t, LONG>( long_data, buffer, buffer_length, out_buffer_length, last_error );
-#endif // _WIN32
-    return r;
-}
-*/
 
 SQLRETURN sqlsrv_buffered_result_set::string_to_double( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
                                                         _Inout_ SQLLEN* out_buffer_length )

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -262,64 +262,6 @@ std::string getUTF8StringFromString( _In_z_ const char* source )
 
 #endif // !_WIN32
 
-template <typename Number, typename Char>
-SQLRETURN string_to_number( _In_z_ Char* string_data, SQLLEN str_len, _Out_writes_bytes_(*out_buffer_length) void* buffer, SQLLEN buffer_length,
-                            _Inout_ SQLLEN* out_buffer_length, _Inout_ sqlsrv_error_auto_ptr& last_error )
-{
-    Number* number_data = reinterpret_cast<Number*>( buffer ); 
-#ifdef _WIN32
-    std::locale loc;    // default locale should match system
-    std::basic_istringstream<Char> is;
-    is.str( string_data );
-    is.imbue( loc );
-    std::ios_base::iostate st = 0;
-
-    std::use_facet< std::num_get< Char > >( loc ).get( std::basic_istream<Char>::_Iter( is.rdbuf()), std::basic_istream<Char>::_Iter( 0 ), is, st, *number_data );
-
-    if ( st & std::ios_base::failbit ) {
-        last_error = new ( sqlsrv_malloc( sizeof( sqlsrv_error ))) sqlsrv_error(( SQLCHAR* ) "22003", ( SQLCHAR* ) "Numeric value out of range", 103 );
-        return SQL_ERROR;
-    }
-
-    *out_buffer_length = sizeof( Number );
-#else
-    std::string str = getUTF8StringFromString( string_data );
-
-    std::istringstream is( str );
-    std::locale loc;    // default locale should match system
-    is.imbue( loc );
-
-    auto& facet = std::use_facet<std::num_get<char>>( is.getloc() );
-    std::istreambuf_iterator<char> beg( is ), end;
-    std::ios_base::iostate err = std::ios_base::goodbit;
-
-    if ( std::is_integral<Number>::value )
-    {
-        long number;
-        facet.get( beg, end, is, err, number );
-
-        *number_data = number;
-    }
-    else
-    {
-        double number;
-        facet.get( beg, end, is, err, number );
-
-        *number_data = number;
-    }
-
-    *out_buffer_length = sizeof( Number );
-
-    if ( is.fail() )
-    {
-        last_error = new ( sqlsrv_malloc(sizeof( sqlsrv_error ))) sqlsrv_error(( SQLCHAR* ) "22003", ( SQLCHAR* ) "Numeric value out of range", 103 );
-        return SQL_ERROR;
-    }
-#endif // _WIN32
-    return SQL_SUCCESS;
-  
-}
-
 // "closure" for the hash table destructor
 struct row_dtor_closure {
 
@@ -1157,7 +1099,16 @@ SQLRETURN sqlsrv_buffered_result_set::string_to_double( _In_ SQLSMALLINT field_i
     unsigned char* row = get_row();
     char* string_data = reinterpret_cast<char*>( &row[meta[field_index].offset] ) + sizeof( SQLULEN );
 
-    return string_to_number<double>( string_data, meta[field_index].length, buffer, buffer_length, out_buffer_length, last_error );
+    double* number_data = reinterpret_cast<double*>(buffer);
+    try {
+        *number_data = std::stod(std::string(string_data));
+    } catch (const std::logic_error& err) {
+        last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
+        return SQL_ERROR;
+    }
+
+    *out_buffer_length = sizeof(double);
+    return SQL_SUCCESS;
 }
 
 SQLRETURN sqlsrv_buffered_result_set::wstring_to_double( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
@@ -1169,7 +1120,20 @@ SQLRETURN sqlsrv_buffered_result_set::wstring_to_double( _In_ SQLSMALLINT field_
     unsigned char* row = get_row();
     SQLWCHAR* string_data = reinterpret_cast<SQLWCHAR*>( &row[meta[field_index].offset] ) + sizeof( SQLULEN ) / sizeof( SQLWCHAR );
 
-    return string_to_number<double>( string_data, meta[field_index].length, buffer, buffer_length, out_buffer_length, last_error );
+    double* number_data = reinterpret_cast<double*>(buffer);
+    try {
+#ifdef _WIN32
+        *number_data = std::stod(std::wstring(string_data));
+#else
+        *number_data = std::stod(getUTF8StringFromString(string_data));
+#endif // _WIN32
+    } catch (const std::logic_error& err) {
+        last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
+        return SQL_ERROR;
+    }
+
+    *out_buffer_length = sizeof(double);
+    return SQL_SUCCESS;
 }
 
 SQLRETURN sqlsrv_buffered_result_set::string_to_long( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
@@ -1181,7 +1145,16 @@ SQLRETURN sqlsrv_buffered_result_set::string_to_long( _In_ SQLSMALLINT field_ind
     unsigned char* row = get_row();
     char* string_data = reinterpret_cast<char*>( &row[meta[field_index].offset] ) + sizeof( SQLULEN );
 
-    return string_to_number<LONG>( string_data, meta[field_index].length, buffer, buffer_length, out_buffer_length, last_error );
+    LONG* number_data = reinterpret_cast<LONG*>(buffer);
+    try {
+        *number_data = std::stol(std::string(string_data));
+    } catch (const std::logic_error& err) {
+        last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
+        return SQL_ERROR;
+    }
+
+    *out_buffer_length = sizeof(LONG);
+    return SQL_SUCCESS;
 }
 
 SQLRETURN sqlsrv_buffered_result_set::wstring_to_long( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
@@ -1193,7 +1166,20 @@ SQLRETURN sqlsrv_buffered_result_set::wstring_to_long( _In_ SQLSMALLINT field_in
     unsigned char* row = get_row();
     SQLWCHAR* string_data = reinterpret_cast<SQLWCHAR*>( &row[meta[field_index].offset] ) + sizeof( SQLULEN ) / sizeof( SQLWCHAR );
 
-    return string_to_number<LONG>( string_data, meta[field_index].length, buffer, buffer_length, out_buffer_length, last_error );
+    LONG* number_data = reinterpret_cast<LONG*>(buffer);
+    try {
+#ifdef _WIN32
+        *number_data = std::stol(std::wstring(string_data));
+#else
+        *number_data = std::stol(getUTF8StringFromString(string_data));
+#endif // _WIN32
+    } catch (const std::logic_error& err) {
+        last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
+        return SQL_ERROR;
+    }
+
+    *out_buffer_length = sizeof(LONG);
+    return SQL_SUCCESS;
 }
 
 SQLRETURN sqlsrv_buffered_result_set::system_to_wide_string( _In_ SQLSMALLINT field_index, _Out_writes_z_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length, 

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -793,7 +793,7 @@ SQLRETURN sqlsrv_buffered_result_set::get_data( _In_ SQLUSMALLINT field_index, _
         case SQL_C_LONG: return sqlsrv_buffered_result_set::to_long(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_BINARY: return sqlsrv_buffered_result_set::to_long(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_CHAR: return sqlsrv_buffered_result_set::long_to_system_string(field_index, buffer, buffer_length, out_buffer_length);
-        case SQL_C_WCHAR: return sqlsrv_buffered_result_set::long_to_wide_string(field_index, buffer, buffer_length, out_buffer_length);
+        //case SQL_C_WCHAR: return sqlsrv_buffered_result_set::long_to_wide_string(field_index, buffer, buffer_length, out_buffer_length);
         default:
             break;
         }
@@ -804,7 +804,7 @@ SQLRETURN sqlsrv_buffered_result_set::get_data( _In_ SQLUSMALLINT field_index, _
         case SQL_C_BINARY: return sqlsrv_buffered_result_set::to_double(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_CHAR: return sqlsrv_buffered_result_set::double_to_system_string(field_index, buffer, buffer_length, out_buffer_length);
         case SQL_C_LONG: return sqlsrv_buffered_result_set::double_to_long(field_index, buffer, buffer_length, out_buffer_length);
-        case SQL_C_WCHAR: return sqlsrv_buffered_result_set::double_to_wide_string(field_index, buffer, buffer_length, out_buffer_length);
+        //case SQL_C_WCHAR: return sqlsrv_buffered_result_set::double_to_wide_string(field_index, buffer, buffer_length, out_buffer_length);
         default:
             break;
         }
@@ -1024,6 +1024,7 @@ SQLRETURN sqlsrv_buffered_result_set::double_to_system_string( _In_ SQLSMALLINT 
     return r;
 }
 
+/*
 SQLRETURN sqlsrv_buffered_result_set::double_to_wide_string( _In_ SQLSMALLINT field_index, _Out_writes_bytes_to_opt_(buffer_length, *out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
                                                              _Inout_ SQLLEN* out_buffer_length )
 {
@@ -1040,7 +1041,7 @@ SQLRETURN sqlsrv_buffered_result_set::double_to_wide_string( _In_ SQLSMALLINT fi
 #endif // _WIN32
     return r;
 }
-
+*/
 SQLRETURN sqlsrv_buffered_result_set::long_to_double( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length, 
                                                       _Out_ SQLLEN* out_buffer_length )
 {
@@ -1073,6 +1074,7 @@ SQLRETURN sqlsrv_buffered_result_set::long_to_system_string( _In_ SQLSMALLINT fi
     return r;
 }
 
+/*
 SQLRETURN sqlsrv_buffered_result_set::long_to_wide_string( _In_ SQLSMALLINT field_index, _Out_writes_bytes_to_opt_(buffer_length, *out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
                                                            _Inout_ SQLLEN* out_buffer_length )
 {
@@ -1089,6 +1091,7 @@ SQLRETURN sqlsrv_buffered_result_set::long_to_wide_string( _In_ SQLSMALLINT fiel
 #endif // _WIN32
     return r;
 }
+*/
 
 SQLRETURN sqlsrv_buffered_result_set::string_to_double( _In_ SQLSMALLINT field_index, _Out_writes_bytes_(*out_buffer_length) void* buffer, _In_ SQLLEN buffer_length,
                                                         _Inout_ SQLLEN* out_buffer_length )

--- a/test/functional/pdo_sqlsrv/pdo_buffered_fetch_types.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_buffered_fetch_types.phpt
@@ -145,14 +145,7 @@ function fetchCharAsInt($conn, $tableName, $column)
         $stmt->bindColumn($column, $value, PDO::PARAM_INT);
         $row = $stmt->fetch(PDO::FETCH_BOUND);
         
-        // TODO 11297: fix this part outside Windows later
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            echo "in fetchCharAsInt: exception should have been thrown!\n";
-        } else {
-            if ($value != 0) {
-                var_dump($value);
-            }
-        }
+        echo "in fetchCharAsInt: exception should have been thrown!\n";
     } catch (PdoException $e) {
         // The (n)varchar field - expect the outOfRange error
         if (strpos($e->getMessage(), $outOfRange) === false) {

--- a/test/functional/pdo_sqlsrv/pdo_buffered_fetch_types.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_buffered_fetch_types.phpt
@@ -215,6 +215,35 @@ function fetchAsNumerics($conn, $tableName, $inputs)
     }
 }
 
+function fetchNumbers($conn, $tableName, $inputs)
+{
+    // Fetch integers and floats as numbers, not strings
+    try {
+        $query = "SELECT c2, c3, c4 FROM $tableName";
+        $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
+
+        $stmt = $conn->prepare($query, array(PDO::ATTR_CURSOR=>PDO::CURSOR_SCROLL, PDO::SQLSRV_ATTR_CURSOR_SCROLL_TYPE=>PDO::SQLSRV_CURSOR_BUFFERED));
+        $stmt->setAttribute(PDO::SQLSRV_ATTR_FETCHES_NUMERIC_TYPE, true);
+        $stmt->execute();
+                     
+        $row = $stmt->fetch(PDO::FETCH_NUM);
+        if ($row[0] !== intval($inputs[1])) {
+            var_dump($row[0]);
+        }
+        $expected = floatval($inputs[2]);
+        if (!compareFloats($expected, $row[1])) {
+            echo "in fetchNumbers: expected $expected but got: ";
+            var_dump($row[1]);
+        }
+        if ($row[2] !== $inputs[3]) {
+            var_dump($row[2]);
+        }
+    } catch (PdoException $e) {
+        echo "Caught exception in fetchAsNumerics:\n";
+        echo $e->getMessage() . PHP_EOL;
+    }
+}
+
 try {
     $conn = connect();
     $conn->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
@@ -253,6 +282,7 @@ try {
     fetchBinaryAsNumber($conn, $tableName, $inputs);
     fetchBinaryAsBinary($conn, $tableName, $inputs);
     fetchAsNumerics($conn, $tableName, $inputs);
+    fetchNumbers($conn, $tableName, $inputs);
     
     // dropTable($conn, $tableName);
     echo "Done\n";

--- a/test/functional/sqlsrv/sqlsrv_buffered_fetch_types.phpt
+++ b/test/functional/sqlsrv/sqlsrv_buffered_fetch_types.phpt
@@ -132,16 +132,9 @@ function fetchAsFloats($conn, $tableName, $inputs)
             }
         } else {
             // The char fields will get errors too
-            // TODO 11297: fix this part outside Windows later
-            if (isWindows()) {
-                if (strpos(sqlsrv_errors()[0]['message'], $outOfRange) === false) {
-                    var_dump($f);
-                    fatalError("in fetchAsFloats: expected $outOfRange for column $i\n");
-                }
-            } else {
-                if ($f != 0.0) {
-                    var_dump($f);
-                }
+            if (strpos(sqlsrv_errors()[0]['message'], $outOfRange) === false) {
+                var_dump($f);
+                fatalError("in fetchAsFloats: expected $outOfRange for column $i\n");
             }
         }
     }
@@ -179,16 +172,9 @@ function fetchAsInts($conn, $tableName, $inputs)
             }
         } elseif ($i >= 5) {
             // The char fields will get errors too
-            // TODO 11297: fix this part outside Windows later
-            if (isWindows()) {
-                if (strpos(sqlsrv_errors()[0]['message'], $outOfRange) === false) {
-                    var_dump($f);
-                    fatalError("in fetchAsInts: expected $outOfRange for column $i\n");
-                }
-            } else {
-                if ($f != 0) {
-                    var_dump($f);
-                }
+            if (strpos(sqlsrv_errors()[0]['message'], $outOfRange) === false) {
+                var_dump($f);
+                fatalError("in fetchAsInts: expected $outOfRange for column $i\n");
             }
         } else {
             $expected = floor($inputs[$i]);


### PR DESCRIPTION
When using client buffers, fetching strings as doubles or integers is inconsistent across platforms. Simplified the corresponding helper methods. Also, no need to keep the numbers to wide strings functions because the drivers no longer convert numeric values to wide strings.