### PR TITLE
Use VS2019 for php 8 in Windows in the build scripts

### DIFF
--- a/buildscripts/buildtools.py
+++ b/buildscripts/buildtools.py
@@ -101,15 +101,10 @@ class BuildUtil(object):
     def compiler_version(self, sdk_dir):
         """Return the appropriate compiler version based on PHP version."""
         if self.vc == '':
-            VC = 'vc14'
+            VC = 'vc15'
             version = self.version_label()
-            if version >= '72':     # Compiler version for PHP 7.2 or above
-                VC = 'vc15'
-                if version == '74':
-                    # Compiler version for PHP 7.4 or above
-                    # Can be compiled using VS 2017 or VS 2019
-                    print('Checking compiler versions...')
-                    VC = self.determine_compiler(sdk_dir, 15)
+            if version == '8':     # Compiler version for PHP 8.0 or above
+                VC = 'vs16'
             self.vc = VC
             print('Compiler: ' + self.vc)
         return self.vc

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindColumn.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindColumn.phpt
@@ -1,7 +1,7 @@
 --TEST--
 a variable bound to a column in a result set
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindParam.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindParam.phpt
@@ -1,7 +1,7 @@
 --TEST--
 after a variable is bound, changing the value changes the value passed in the query
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindParam_2.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindParam_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 accesses an output parameter
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindParam_3.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindParam_3.phpt
@@ -1,7 +1,7 @@
 --TEST--
 uses an input/output parameter
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindValue.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_bindValue.phpt
@@ -1,7 +1,7 @@
 --TEST--
 after a value $contact is bound, changing the value does not change the value passed in the query
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_closeCursor.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_closeCursor.phpt
@@ -1,7 +1,7 @@
 --TEST--
 closes the cursor
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_columnCount.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_columnCount.phpt
@@ -1,7 +1,7 @@
 --TEST--
 returns the number of columns in a result set for 3 queries
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_debugDumpParams.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_debugDumpParams.phpt
@@ -1,7 +1,7 @@
 --TEST--
 displays a prepared statement
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_errorCode.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_errorCode.phpt
@@ -1,11 +1,12 @@
 --TEST--
 shows the error code of a SQL query with a mispelled table
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');
 $conn = new PDO( "sqlsrv:server=$server; Database = $databaseName", "$uid", "$pwd");
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 $stmt = $conn->prepare('SELECT * FROM Person.Addressx');
 
 $stmt->execute();
@@ -13,8 +14,8 @@ echo "Error Code: ";
 print $stmt->errorCode();
 
 // free the statement and connection 
-$stmt=null;
-$conn=null;
+unset($stmt);
+unset($conn);
 ?>
 --EXPECT--
 Error Code: 42S02

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_errorInfo.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_errorInfo.phpt
@@ -1,19 +1,20 @@
 --TEST--
 reports the error info of a SQL statement with a mispelled table name
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');
 $conn = new PDO( "sqlsrv:server=$server ; Database = $databaseName", "$uid", "$pwd");
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 $stmt = $conn->prepare('SELECT * FROM Person.Addressx');
 
 $stmt->execute();
 print_r ($stmt->errorInfo());
 
 // free the statement and connection 
-$stmt=null;
-$conn=null;
+unset($stmt);
+unset($conn);
 ?>
 --EXPECTREGEX--
 Array

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_execute.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_execute.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Executes a statement
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetch.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetch.phpt
@@ -1,7 +1,7 @@
 --TEST--
 fetch with all fetch styles
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchAll.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchAll.phpt
@@ -1,7 +1,7 @@
 --TEST--
 fetches the rows in a result set in an array
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchColumn.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchColumn.phpt
@@ -1,7 +1,7 @@
 --TEST--
 fetches a column in a row
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchObject.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchObject.phpt
@@ -1,7 +1,7 @@
 --TEST--
 fetches the next row as an object
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchObject_class_name.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchObject_class_name.phpt
@@ -1,7 +1,7 @@
 --TEST--
 fetches the next row as an object of a user defined class
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	//create class of contactType

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_getColumnMeta.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_getColumnMeta.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves metadata for a column
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_nextRowset.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_nextRowset.phpt
@@ -1,7 +1,7 @@
 --TEST--
 moves the cursor to the next result set and fetches results
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_rowCount.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_rowCount.phpt
@@ -1,7 +1,7 @@
 --TEST--
 returns the number of rows added to a table; returns the number of rows in a result set when you specify a scrollable cursor
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_setAttribute.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_setAttribute.phpt
@@ -1,7 +1,7 @@
 --TEST--
 sets the query timeout attribute
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_setFetchMode.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_setFetchMode.phpt
@@ -1,7 +1,7 @@
 --TEST--
 specifies the fetch mode before fetching
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_beginTransaction.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_beginTransaction.phpt
@@ -1,7 +1,7 @@
 --TEST--
 starts a transaction, insert 2 rows and commit the transaction
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_construct.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_construct.phpt
@@ -1,7 +1,7 @@
 --TEST--
 connect to a server and specify a database
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_construct_2.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_construct_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 connect to a server, specifying the database later
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_construct_MARS.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_construct_MARS.phpt
@@ -1,7 +1,7 @@
 --TEST--
 connect to a server, setting MARS to false
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_errorCode.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_errorCode.phpt
@@ -1,18 +1,19 @@
 --TEST--
 reports the error code of querying a misspelled column
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');
 $conn = new PDO( "sqlsrv:Server=$server ; Database = $databaseName ", "$uid", "$pwd");
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 $query = "SELECT * FROM Person.Address where Cityx = 'Essen'";
 
 $conn->query($query);
 print $conn->errorCode();
 
 //free the connection
-$conn=null;
+unset($conn);
 ?>
 --EXPECT--
 42S22

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_errorInfo.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_errorInfo.phpt
@@ -1,11 +1,12 @@
 --TEST--
 reports the error info of querying a misspelled column
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');
 $conn = new PDO( "sqlsrv:Server=$server ; Database = $databaseName ", "$uid", "$pwd");
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 $query = "SELECT * FROM Person.Address where Cityx = 'Essen'";
 
 $conn->query($query);

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_exec.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_exec.phpt
@@ -1,7 +1,7 @@
 --TEST--
 execute a delete and reports how many rows were deleted
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_getAttribute.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_getAttribute.phpt
@@ -1,11 +1,12 @@
 --TEST--
 shows the PDO::ATR_ERRMODE attribute, before and after changing its value
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');
 $conn = new PDO( "sqlsrv:Server=$server ; Database = $databaseName", "$uid", "$pwd");
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
 $attributes1 = array( "ERRMODE" );
 foreach ( $attributes1 as $val ) {
@@ -13,7 +14,7 @@ foreach ( $attributes1 as $val ) {
      var_dump ($conn->getAttribute( constant( "PDO::ATTR_$val" ) ));
 }
 
-$conn->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $attributes1 = array( "ERRMODE" );
 foreach ( $attributes1 as $val ) {
@@ -25,7 +26,7 @@ foreach ( $attributes1 as $val ) {
 print_r($conn->getAttribute( PDO::ATTR_CLIENT_VERSION ));
 
 //free the connection
-$conn=null;
+unset($conn);
 ?>
 --EXPECTREGEX--
 PDO::ATTR_ERRMODE: int\(0\)

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_getAvailableDrivers.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_getAvailableDrivers.phpt
@@ -1,7 +1,7 @@
 --TEST--
 check if sqlsrv is in the array of available PDO drivers
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 $drivers = PDO::getAvailableDrivers();

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_prepare.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_prepare.phpt
@@ -1,7 +1,7 @@
 --TEST--
 prepares a statement with parameter markers and forward-only (server-side) cursor
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_prepare_2.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_prepare_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 prepares a statement with a client-side cursor
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_prepare_cursor.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_prepare_cursor.phpt
@@ -1,7 +1,7 @@
 --TEST--
 prepares a statement with a client-side cursor and specifies scroll type to buffered
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_query.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_query.phpt
@@ -1,7 +1,7 @@
 --TEST--
 default query; query for a column; query with a new class; query into an existing class
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_quote.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_quote.phpt
@@ -1,7 +1,7 @@
 --TEST--
 insert with quoted parameters
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_setAttribute.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_setAttribute.phpt
@@ -1,11 +1,12 @@
 --TEST--
 sets to PDO::ATTR_ERRMODE
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
    require('connect.inc');	
    $conn = new PDO( "sqlsrv:server=$server ; Database = $databaseName", "$uid", "$pwd");
+   $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
    $attributes1 = array( "ERRMODE" );
    foreach ( $attributes1 as $val ) {
@@ -22,7 +23,7 @@ sets to PDO::ATTR_ERRMODE
    }
    
    //free the connection
-   $conn=null;
+   unset($conn);
 ?>
 --EXPECT--
 PDO::ATTR_ERRMODE: int(0)

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_setAttribute_direct_query.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_setAttribute_direct_query.phpt
@@ -1,42 +1,45 @@
 --TEST--
 sets to PDO::SQLSRV_ATTR_DIRECT_QUERY
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
-   require('connect.inc');	
-   $conn = new PDO("sqlsrv:Server=$server", "$uid", "$pwd");
-   $conn->setAttribute(constant('PDO::SQLSRV_ATTR_DIRECT_QUERY'), true);
+    require('connect.inc');	
+    $conn = new PDO("sqlsrv:Server=$server", "$uid", "$pwd");
+    $conn->setAttribute(constant('PDO::SQLSRV_ATTR_DIRECT_QUERY'), true);
 
-   $stmt1 = $conn->query("DROP TABLE #php_test_table");
+    $tableName = 'pdo_direct_query';
+    $tsql = "IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'" . $tableName . "') AND type in (N'U')) DROP TABLE $tableName";
 
-   $stmt2 = $conn->query("CREATE TABLE #php_test_table ([c1_int] int, [c2_int] int)");
+    $stmt1 = $conn->query($tsql);
+    $stmt2 = $conn->query("CREATE TABLE $tableName ([c1_int] int, [c2_int] int)");
 
-   $v1 = 1;
-   $v2 = 2;
+    $v1 = 1;
+    $v2 = 2;
 
-   $stmt3 = $conn->prepare("INSERT INTO #php_test_table (c1_int, c2_int) VALUES (:var1, :var2)");
+    $stmt3 = $conn->prepare("INSERT INTO $tableName (c1_int, c2_int) VALUES (:var1, :var2)");
 
-   if ($stmt3) {
+    if ($stmt3) {
       $stmt3->bindValue(1, $v1);
       $stmt3->bindValue(2, $v2);
 
-      if ($stmt3->execute())
+      if ($stmt3->execute()) {
          echo "Execution succeeded\n";     
-      else
+      } else {
          echo "Execution failed\n";
-   }
-   else
+      }
+    } else {
       var_dump($conn->errorInfo());
+    }
 
-   $stmt4 = $conn->query("DROP TABLE #php_test_table");
+    $stmt4 = $conn->query("DROP TABLE $tableName");
 
-   // free the statements and connection
-   $stmt1=null;
-   $stmt2=null;
-   $stmt3=null;
-   $stmt4=null;
-   $conn=null;
-   ?>
+    // free the statements and connection
+    unset($stmt1);
+    unset($stmt2);
+    unset($stmt3);
+    unset($stmt4);
+    unset($conn);
+?>
 --EXPECT--
 Execution succeeded

--- a/test/bvt/pdo_sqlsrv/pdo_bindParam_inout_double.phpt
+++ b/test/bvt/pdo_sqlsrv/pdo_bindParam_inout_double.phpt
@@ -1,7 +1,7 @@
 --TEST--
 call a stored procedure and retrieve the errorNumber that is returned
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/pdo_bindParam_inout_integer.phpt
+++ b/test/bvt/pdo_sqlsrv/pdo_bindParam_inout_integer.phpt
@@ -1,7 +1,7 @@
 --TEST--
 call a stored procedure and retrieve the errorNumber that is returned
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/pdo_bindParam_inout_string.phpt
+++ b/test/bvt/pdo_sqlsrv/pdo_bindParam_inout_string.phpt
@@ -1,7 +1,7 @@
 --TEST--
 call a stored procedure and retrieve the errorString that is returned
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	require('connect.inc');

--- a/test/bvt/pdo_sqlsrv/skipif.inc
+++ b/test/bvt/pdo_sqlsrv/skipif.inc
@@ -1,0 +1,4 @@
+<?php
+if (!extension_loaded("pdo_sqlsrv")) {
+    die("skip Extension not loaded");
+}

--- a/test/bvt/sqlsrv/msdn_sqlsrv_begin_transaction.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_begin_transaction.phpt
@@ -1,7 +1,7 @@
 --TEST--
 executes two queries as part of a transaction
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_begin_transaction_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_begin_transaction_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 delete in a transaction
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_cancel.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_cancel.phpt
@@ -1,7 +1,7 @@
 --TEST--
 executes a query, then comsumes and counts results until reaches a specified amount. The remaining query results are then discarded.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_cancel_1.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_cancel_1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 cancels a statement then reuse.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_client_info.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_client_info.phpt
@@ -1,7 +1,7 @@
 --TEST--
 client information.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_close.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_close.phpt
@@ -1,7 +1,7 @@
 --TEST--
 closes a connection.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_commit.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_commit.phpt
@@ -1,8 +1,7 @@
 --TEST--
 executes two queries as part of a transaction. If both queries are successful, the transaction is committed.
 --SKIPIF--
-
-?>
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_configure.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_configure.phpt
@@ -1,8 +1,7 @@
 --TEST--
 disables the default error-handling behaviour using configure
 --SKIPIF--
-
-?>
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication. */

--- a/test/bvt/sqlsrv/msdn_sqlsrv_configure_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_configure_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 disables the default error-handling behaviour using configure and returns warnings
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Turn off the default behavior of treating errors as warnings.

--- a/test/bvt/sqlsrv/msdn_sqlsrv_connect.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_connect.phpt
@@ -1,7 +1,7 @@
 --TEST--
 creates and opens a connection using Windows Authentication.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_connect_MARS.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_connect_MARS.phpt
@@ -1,7 +1,7 @@
 --TEST--
 disables MARS support.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_connect_returnDateAsStrings.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_connect_returnDateAsStrings.phpt
@@ -1,7 +1,7 @@
 --TEST--
 specifies to retrieve date and time types as string when connecting.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_connect_returnDatesAsStrings_utf8.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_connect_returnDatesAsStrings_utf8.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves dates as string by specifying UTF-8 and ReturnDatesAsStrings when connecting.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_connect_utf8.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_connect_utf8.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves UTF-8 encoded data by specifying the UTF-8 character set when making the connection
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_date_format.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_date_format.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieve date as PHP type with ReturnDatesAsStrings off by default.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_errors.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_errors.phpt
@@ -1,7 +1,7 @@
 --TEST--
 displays errors that occur during a failed statement execution
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_execute.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_execute.phpt
@@ -1,7 +1,7 @@
 --TEST--
 executes a statement that updates a field.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_execute_datetime.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_execute_datetime.phpt
@@ -1,8 +1,7 @@
 --TEST--
 execute with datetime type in bind parameters.
 --SKIPIF--
-
-?>
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_execute_string.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_execute_string.phpt
@@ -1,8 +1,7 @@
 --TEST--
 execute with string type in bind parameters.
 --SKIPIF--
-
-?>
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_fetch.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_fetch.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieve a row of data.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_fetch_array.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_fetch_array.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves each row of a result set as an associative array.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_fetch_array_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_fetch_array_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves each row of a result set as a numerically indexed array.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_fetch_object.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_fetch_object.phpt
@@ -1,8 +1,7 @@
 --TEST--
 retrieves each row of a result set as a PHP object
 --SKIPIF--
-
-?>
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_fetch_object_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_fetch_object_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves each row of a result set as an instance of the Product class defined in the script.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Define the Product class. */

--- a/test/bvt/sqlsrv/msdn_sqlsrv_field_metadata.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_field_metadata.phpt
@@ -1,7 +1,7 @@
 --TEST--
 creates a statement resource then retrieves and displays the field metadata
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_free_stmt.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_free_stmt.phpt
@@ -1,7 +1,7 @@
 --TEST--
 creates a statement resource, executes a simple query, and free all resources associated with the statement
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_get_field.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_get_field.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves a row of data
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_get_field_stream.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_get_field_stream.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves datatime as string and nvarchar as stream.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and 

--- a/test/bvt/sqlsrv/msdn_sqlsrv_get_field_stream_char.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_get_field_stream_char.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves row as a stream specified as a character stream.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /*Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_get_field_string_utf8.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_get_field_string_utf8.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieves dates as strings by specifying UTF-8 when fetching the string.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_has_rows.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_has_rows.phpt
@@ -1,7 +1,7 @@
 --TEST--
 indicate if the result set has one or more rows.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_next_result.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_next_result.phpt
@@ -1,7 +1,7 @@
 --TEST--
 first result is consumed without calling next_result, the next result is made available by calling next_result
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and 

--- a/test/bvt/sqlsrv/msdn_sqlsrv_next_result_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_next_result_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 executes a batch query that retrieves information, insert an entry, then again retrieves information
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_num_fields.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_num_fields.phpt
@@ -1,7 +1,7 @@
 --TEST--
 retrieve all fields
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_num_rows.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_num_rows.phpt
@@ -1,7 +1,7 @@
 --TEST--
 num_rows with a ekyset cursor should work.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_num_rows_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_num_rows_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 when there is a batch query, the number of rows is only available when use a client-side cursor.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_prepare.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_prepare.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Prepares and executes a statement.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_prepare_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_prepare_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Prepares a statement and then re-execute it with different parameter values.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_prepare_bind_param.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_prepare_bind_param.phpt
@@ -1,7 +1,7 @@
 --TEST--
 binding of variables using prepare function
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_prepare_scrollable_buffered.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_prepare_scrollable_buffered.phpt
@@ -1,7 +1,7 @@
 --TEST--
 server side cursor specified when preparing
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Query insert into a table
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Query update a field in a table
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_bind_param.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_bind_param.phpt
@@ -1,7 +1,7 @@
 --TEST--
 updates the quantity in a table, the quantity and product ID are parameters in the UPDATE query.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_param_inout.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_param_inout.phpt
@@ -1,7 +1,7 @@
 --TEST--
 queries a call procedure with an in-out parameter.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_param_out.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_param_out.phpt
@@ -1,7 +1,7 @@
 --TEST--
 queries a call to procedure with input and output parameters.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to a server using Windows Authentication and 

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_scrollable.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_scrollable.phpt
@@ -1,7 +1,7 @@
 --TEST--
 server side cursor specified when querying
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_scrollable_buffered.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_scrollable_buffered.phpt
@@ -1,7 +1,7 @@
 --TEST--
 client side buffered cursor
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_sqltype.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_sqltype.phpt
@@ -1,7 +1,7 @@
 --TEST--
 sqlsrv types are specified for the parameters in query.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and 

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_stream.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_stream.phpt
@@ -1,6 +1,7 @@
 --TEST--
 insert stream.
 --SKIPIF--
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_utf8.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_utf8.phpt
@@ -1,7 +1,7 @@
 --TEST--
 specify the UTF-8 character set when querying
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 

--- a/test/bvt/sqlsrv/msdn_sqlsrv_rollback.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_rollback.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Rolls back the current transaction on the specified connection and returns the connection to the auto-commit mode.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_rows_affected.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_rows_affected.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Returns the number of rows modified by the last statement executed.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_send_stream_data.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_send_stream_data.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Sends data from parameter streams to the server
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 require('connect.inc');

--- a/test/bvt/sqlsrv/msdn_sqlsrv_send_stream_data_no_sendStreamParamsAtExec.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_send_stream_data_no_sendStreamParamsAtExec.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Send stream data with SendStreamParamsAtExec turned off.
 --SKIPIF--
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication and

--- a/test/bvt/sqlsrv/msdn_sqlsrv_server_info.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_server_info.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Returns information about the server.
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 /* Connect to the local server using Windows Authentication. */

--- a/test/bvt/sqlsrv/skipif.inc
+++ b/test/bvt/sqlsrv/skipif.inc
@@ -1,0 +1,7 @@
+<?php
+
+if (!extension_loaded("sqlsrv")) {
+    die("skip extension not loaded");
+}
+
+?>

--- a/test/bvt/sqlsrv/sqlsrv_param_inout.phpt
+++ b/test/bvt/sqlsrv/sqlsrv_param_inout.phpt
@@ -1,7 +1,7 @@
 --TEST--
 call a stored procedure (SQLSRV Driver) and retrieve the errorNumber that is returned
 --SKIPIF--
-
+<?php require('skipif.inc'); ?>
 --FILE--
 <?php
 	// Connect to the database


### PR DESCRIPTION
No longer require VS 2015. Also, BVT tests are updated to run against PHP 8.