### PR TITLE
Fixed get_field_as_string when using display size for large types

### DIFF
--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -2590,9 +2590,11 @@ void get_field_as_string( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_ind
             break;
         }
 
-        // if this is a large type, then read the first few bytes to get the actual length from SQLGetData
-        if( sql_display_size == 0 || sql_display_size == INT_MAX ||
-            sql_display_size == INT_MAX >> 1 || sql_display_size == UINT_MAX - 1 ) {
+        // If this is a large type, then read the first few bytes to get the actual length from SQLGetData
+        // The user may use "SET TEXTSIZE" to specify the size of varchar(max), nvarchar(max), 
+        // varbinary(max), text, ntext, and image data returned by a SELECT statement. 
+        // For varchar(max) and nvarchar(max), sql_display_size will be 0, regardless
+        if (sql_display_size == 0 || (sql_display_size > SQL_SERVER_MAX_FIELD_SIZE && (sql_field_type == SQL_WLONGVARCHAR || sql_field_type == SQL_LONGVARCHAR || sql_field_type == SQL_LONGVARBINARY))) {
 
             field_len_temp = intial_field_len;
 

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -2594,7 +2594,10 @@ void get_field_as_string( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_ind
         // The user may use "SET TEXTSIZE" to specify the size of varchar(max), nvarchar(max), 
         // varbinary(max), text, ntext, and image data returned by a SELECT statement. 
         // For varchar(max) and nvarchar(max), sql_display_size will be 0, regardless
-        if (sql_display_size == 0 || (sql_display_size > SQL_SERVER_MAX_FIELD_SIZE && (sql_field_type == SQL_WLONGVARCHAR || sql_field_type == SQL_LONGVARCHAR || sql_field_type == SQL_LONGVARBINARY))) {
+        if (sql_display_size == 0 || sql_display_size == INT_MAX ||
+            sql_display_size == INT_MAX >> 1 || sql_display_size == UINT_MAX - 1 ||
+            (sql_display_size > SQL_SERVER_MAX_FIELD_SIZE && 
+                (sql_field_type == SQL_WLONGVARCHAR || sql_field_type == SQL_LONGVARCHAR || sql_field_type == SQL_LONGVARBINARY))) {
 
             field_len_temp = intial_field_len;
 

--- a/test/functional/pdo_sqlsrv/pdo_1170_direct_query_with_textsize.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_1170_direct_query_with_textsize.phpt
@@ -1,0 +1,71 @@
+--TEST--
+GitHub issue 1170 - PDO::SQLSRV_ATTR_DIRECT_QUERY with SET TEXTSIZE
+--DESCRIPTION--
+This test verifies that setting PDO::SQLSRV_ATTR_DIRECT_QUERY to true with a user defined TEXTSIZE will work
+--ENV--
+PHPT_EXEC=true
+--SKIPIF--
+<?php require('skipif_mid-refactor.inc'); ?>
+--FILE--
+<?php
+require_once("MsSetup.inc");
+require_once("MsCommon_mid-refactor.inc");
+
+function composeQuery($input, $type) 
+{
+    $sql = "
+    SET NOCOUNT ON;
+    DECLARE @T1 TABLE (C1 NVARCHAR(10), C2 $type)
+    INSERT INTO @T1 (C1,C2) VALUES ('$input', NULL)
+    SELECT * FROM @T1
+    ";
+    
+    return $sql;
+}
+
+function runTest($conn, $type, $size)
+{
+    echo "Test with $type and $size\n";
+    
+    $input = 'TEST1';
+    $options = array(PDO::SQLSRV_ATTR_DIRECT_QUERY => true);
+
+    $sql = "SET TEXTSIZE $size";
+    $stmt = $conn->prepare($sql, $options);
+    $stmt->execute();
+    unset($stmt);
+
+    $sql = composeQuery($input, $type);
+    $stmt = $conn->prepare($sql, $options);
+    $stmt->execute();
+
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row['C1'] != $input || !is_null($row['C2'])) {
+        var_dump($row);
+    }
+    unset($stmt);
+}
+
+try {  
+    $conn = connect();
+
+    $options = array(PDO::SQLSRV_ATTR_DIRECT_QUERY => true);
+
+    runTest($conn, 'TEXT', 4800);
+    runTest($conn, 'NTEXT', 129024);
+    runTest($conn, 'IMAGE', 10000);
+
+    unset($conn);
+
+    echo "Done\n";
+} catch (PdoException $e) {
+    echo $e->getMessage() . PHP_EOL;
+}
+
+?>
+--EXPECT--
+Test with TEXT and 4800
+Test with NTEXT and 129024
+Test with IMAGE and 10000
+Done
+


### PR DESCRIPTION
Related to #1170 