### PR TITLE
Used size of integers for rank field instead

### DIFF
--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -576,7 +576,7 @@ namespace data_classification {
         // Get rank info
         if (getRankInfo) {
             queryrank = *(reinterpret_cast<long*>(ptr));
-            ptr += sizeof(long);
+            ptr += sizeof(int);
             meta->rank = queryrank;
         }
 
@@ -605,7 +605,7 @@ namespace data_classification {
 
                 if (getRankInfo) {
                     colrank = *(reinterpret_cast<long*>(ptr));
-                    ptr += sizeof(long);
+                    ptr += sizeof(int);
                     pair.rank = colrank;
                 }
 


### PR DESCRIPTION
long is 64 bits on Linux and the data sent back from server will always be 32 bits for ranks