### PR TITLE
Minimized warnings during compilation 

### DIFF
--- a/source/pdo_sqlsrv/pdo_init.cpp
+++ b/source/pdo_sqlsrv/pdo_init.cpp
@@ -116,7 +116,7 @@ void pdo_error_dtor( _Inout_ zval* elem ) {
 
 PHP_MINIT_FUNCTION(pdo_sqlsrv)
 {
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( type );
 
     // our global variables are initialized in the RINIT function
 #if defined(ZTS)
@@ -185,7 +185,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_sqlsrv)
 {
     try {
 
-        SQLSRV_UNUSED( type );
+        // SQLSRV_UNUSED( type );
 
         UNREGISTER_INI_ENTRIES();
 
@@ -213,8 +213,8 @@ PHP_MSHUTDOWN_FUNCTION(pdo_sqlsrv)
 
 PHP_RINIT_FUNCTION(pdo_sqlsrv)
 {
-    SQLSRV_UNUSED( module_number );
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( module_number );
+    // SQLSRV_UNUSED( type );
 
 #if defined(ZTS) 
     ZEND_TSRMLS_CACHE_UPDATE();
@@ -247,8 +247,8 @@ PHP_RINIT_FUNCTION(pdo_sqlsrv)
 
 PHP_RSHUTDOWN_FUNCTION(pdo_sqlsrv)
 {
-    SQLSRV_UNUSED( module_number );
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( module_number );
+    // SQLSRV_UNUSED( type );
 
     PDO_LOG_NOTICE("pdo_sqlsrv: entering rshutdown");
 

--- a/source/pdo_sqlsrv/pdo_util.cpp
+++ b/source/pdo_sqlsrv/pdo_util.cpp
@@ -465,7 +465,7 @@ pdo_error PDO_ERRORS[] = {
     { UINT_MAX, {} }
 };
 
-bool pdo_sqlsrv_handle_env_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ bool warning, 
+bool pdo_sqlsrv_handle_env_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ int warning, 
                                   _In_opt_ va_list* print_args )
 {
     SQLSRV_ASSERT((ctx != NULL), "pdo_sqlsrv_handle_env_error: sqlsrv_context was null");
@@ -488,7 +488,7 @@ bool pdo_sqlsrv_handle_env_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned
 }
 
 // pdo error handler for the dbh context.
-bool pdo_sqlsrv_handle_dbh_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ bool warning, 
+bool pdo_sqlsrv_handle_dbh_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ int warning, 
                                   _In_opt_ va_list* print_args )
 {
     pdo_dbh_t* dbh = reinterpret_cast<pdo_dbh_t*>( ctx.driver());
@@ -520,7 +520,7 @@ bool pdo_sqlsrv_handle_dbh_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned
 }
 
 // PDO error handler for the statement context.
-bool pdo_sqlsrv_handle_stmt_error(_Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ bool warning,
+bool pdo_sqlsrv_handle_stmt_error(_Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ int warning,
     _In_opt_ va_list* print_args)
 {
     pdo_stmt_t* pdo_stmt = reinterpret_cast<pdo_stmt_t*>(ctx.driver());

--- a/source/pdo_sqlsrv/php_pdo_sqlsrv_int.h
+++ b/source/pdo_sqlsrv/php_pdo_sqlsrv_int.h
@@ -285,11 +285,11 @@ struct pdo_error {
 // called when an error occurs in the core layer.  These routines are set as the error_callback in a
 // context.  The context is passed to this function since it contains the function
 
-bool pdo_sqlsrv_handle_env_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ bool warning, 
+bool pdo_sqlsrv_handle_env_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ int warning, 
                                   _In_opt_ va_list* print_args );
-bool pdo_sqlsrv_handle_dbh_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ bool warning, 
+bool pdo_sqlsrv_handle_dbh_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ int warning, 
                                   _In_opt_ va_list* print_args );
-bool pdo_sqlsrv_handle_stmt_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ bool warning, 
+bool pdo_sqlsrv_handle_stmt_error( _Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int sqlsrv_error_code, _In_opt_ int warning, 
                                    _In_opt_ va_list* print_args );
 
 // common routine to transfer a sqlsrv_context's error to a PDO zval

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -1066,7 +1066,7 @@ SQLRETURN sqlsrv_buffered_result_set::string_to_double( _In_ SQLSMALLINT field_i
     double* number_data = reinterpret_cast<double*>(buffer);
     try {
         *number_data = std::stod(std::string(string_data));
-    } catch (const std::logic_error& err) {
+    } catch (const std::logic_error& ) {
         last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
         return SQL_ERROR;
     }
@@ -1091,7 +1091,7 @@ SQLRETURN sqlsrv_buffered_result_set::wstring_to_double( _In_ SQLSMALLINT field_
 #else
         *number_data = std::stod(getUTF8StringFromString(string_data));
 #endif // _WIN32
-    } catch (const std::logic_error& err) {
+    } catch (const std::logic_error& ) {
         last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
         return SQL_ERROR;
     }
@@ -1112,7 +1112,7 @@ SQLRETURN sqlsrv_buffered_result_set::string_to_long( _In_ SQLSMALLINT field_ind
     LONG* number_data = reinterpret_cast<LONG*>(buffer);
     try {
         *number_data = std::stol(std::string(string_data));
-    } catch (const std::logic_error& err) {
+    } catch (const std::logic_error& ) {
         last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
         return SQL_ERROR;
     }
@@ -1137,7 +1137,7 @@ SQLRETURN sqlsrv_buffered_result_set::wstring_to_long( _In_ SQLSMALLINT field_in
 #else
         *number_data = std::stol(getUTF8StringFromString(string_data));
 #endif // _WIN32
-    } catch (const std::logic_error& err) {
+    } catch (const std::logic_error& ) {
         last_error = new (sqlsrv_malloc(sizeof(sqlsrv_error))) sqlsrv_error((SQLCHAR*) "22003", (SQLCHAR*) "Numeric value out of range", 103);
         return SQL_ERROR;
     }

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -1931,7 +1931,7 @@ DWORD core_sqlsrv_format_message( _Out_ char* output_buffer, _In_ unsigned outpu
 
 // convenience functions that overload either a reference or a pointer so we can use
 // either in the CHECK_* functions.
-inline bool call_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned long sqlsrv_error_code, _In_ bool warning, ... )
+inline bool call_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned long sqlsrv_error_code, _In_ int warning, ... )
 {
     va_list print_params;
     va_start( print_params, warning );
@@ -1940,7 +1940,7 @@ inline bool call_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned long 
     return ignored;
 }
 
-inline bool call_error_handler( _Inout_ sqlsrv_context* ctx, _In_ unsigned long sqlsrv_error_code, _In_ bool warning, ... )
+inline bool call_error_handler( _Inout_ sqlsrv_context* ctx, _In_ unsigned long sqlsrv_error_code, _In_ int warning, ... )
 {
     va_list print_params;
     va_start( print_params, warning );
@@ -1985,7 +1985,7 @@ inline bool is_truncated_warning( _In_ SQLCHAR* state )
     bool flag##unique = (condition);                                 \
     bool ignored##unique = true;                                       \
     if (flag##unique) {                                              \
-        ignored##unique = call_error_handler( context, ssphp, /*warning*/false, ## __VA_ARGS__ ); \
+        ignored##unique = call_error_handler( context, ssphp, /*warning*/0, ## __VA_ARGS__ ); \
     }  \
     if( !ignored##unique )
 
@@ -2005,7 +2005,7 @@ inline bool is_truncated_warning( _In_ SQLCHAR* state )
 #define CHECK_WARNING_AS_ERROR_UNIQUE(  unique, condition, context, ssphp, ... )   \
     bool ignored##unique = true;    \
     if( condition ) { \
-        ignored##unique = call_error_handler( context, ssphp, /*warning*/true, ## __VA_ARGS__ ); \
+        ignored##unique = call_error_handler( context, ssphp, /*warning*/1, ## __VA_ARGS__ ); \
     }   \
     if( !ignored##unique )
 
@@ -2014,7 +2014,7 @@ inline bool is_truncated_warning( _In_ SQLCHAR* state )
 
 #define CHECK_SQL_WARNING( result, context, ... )        \
     if( result == SQL_SUCCESS_WITH_INFO ) {              \
-        (void)call_error_handler( context, 0, /*warning*/ true, ## __VA_ARGS__ ); \
+        (void)call_error_handler( context, 0, /*warning*/1, ## __VA_ARGS__ ); \
     }
 
 #define CHECK_CUSTOM_WARNING_AS_ERROR( condition, context, ssphp, ... ) \
@@ -2027,16 +2027,16 @@ inline bool is_truncated_warning( _In_ SQLCHAR* state )
     SQLSRV_ASSERT( result != SQL_INVALID_HANDLE, "Invalid handle returned." );  \
     bool ignored = true;                                   \
     if( result == SQL_ERROR ) {                            \
-        ignored = call_error_handler( context, SQLSRV_ERROR_ODBC, false, ##__VA_ARGS__ ); \
+        ignored = call_error_handler( context, SQLSRV_ERROR_ODBC, 0, ##__VA_ARGS__ ); \
     }                                                      \
     else if( result == SQL_SUCCESS_WITH_INFO ) {           \
-        ignored = call_error_handler( context, SQLSRV_ERROR_ODBC, true, ##__VA_ARGS__ ); \
+        ignored = call_error_handler( context, SQLSRV_ERROR_ODBC, 1, ##__VA_ARGS__ ); \
     }                                                      \
     if( !ignored )
 
 // throw an exception after it has been hooked into the custom error handler
 #define THROW_CORE_ERROR( ctx, custom, ... ) \
-  (void)call_error_handler( ctx, custom, /*warning*/ false, ## __VA_ARGS__ ); \
+  (void)call_error_handler( ctx, custom, /*warning*/0, ## __VA_ARGS__ ); \
   throw core::CoreException();
 
 //*********************************************************************************************************************************

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -876,7 +876,7 @@ struct sqlsrv_conn;
 // a driver specific callback for processing errors.
 // ctx - the context holding the handles
 // sqlsrv_error_code - specific error code to return.
-typedef bool (*error_callback)( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_error_code, _In_ bool error, _In_opt_ va_list* print_args );
+typedef bool (*error_callback)( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_error_code, _In_ int error, _In_opt_ va_list* print_args );
 
 // sqlsrv_context
 // a context holds relevant information to be passed with a connection and statement objects.

--- a/source/shared/localizationimpl.cpp
+++ b/source/shared/localizationimpl.cpp
@@ -469,7 +469,7 @@ size_t SystemLocale::Utf8To16( const char *src, SSIZE_T cchSrc, WCHAR *dest, siz
             }
             usrc++;
             ucode = (ucode&15)<<12 | (c1&0x3F)<<6 | (c2&0x3F);
-            if (ucode < 0x800 || ucode >= 0xD800 && ucode <= 0xDFFF)
+            if (ucode < 0x800 || (ucode >= 0xD800 && ucode <= 0xDFFF))
             {
                 goto Invalid;
             }
@@ -511,7 +511,7 @@ size_t SystemLocale::Utf8To16( const char *src, SSIZE_T cchSrc, WCHAR *dest, siz
 
             if (ucode < 0x10000   // overlong encoding
              || ucode > 0x10FFFF  // exceeds Unicode range
-             || ucode >= 0xD800 && ucode <= 0xDFFF) // surrogate pairs
+             || (ucode >= 0xD800 && ucode <= 0xDFFF)) // surrogate pairs
             {
                 goto Invalid;
             }
@@ -594,7 +594,7 @@ size_t SystemLocale::Utf8To16Strict( const char *src, SSIZE_T cchSrc, WCHAR *des
             }
             usrc++;
             ucode = (ucode&15)<<12 | (c1&0x3F)<<6 | (c2&0x3F);
-            if (ucode < 0x800 || ucode >= 0xD800 && ucode <= 0xDFFF)
+            if (ucode < 0x800 || (ucode >= 0xD800 && ucode <= 0xDFFF))
             {
                 goto Invalid;
             }
@@ -636,7 +636,7 @@ size_t SystemLocale::Utf8To16Strict( const char *src, SSIZE_T cchSrc, WCHAR *des
 
             if (ucode < 0x10000   // overlong encoding
              || ucode > 0x10FFFF  // exceeds Unicode range
-             || ucode >= 0xD800 && ucode <= 0xDFFF) // surrogate pairs
+             || (ucode >= 0xD800 && ucode <= 0xDFFF)) // surrogate pairs
             {
                 goto Invalid;
             }
@@ -794,7 +794,7 @@ size_t SystemLocale::Utf8From16( const WCHAR *src, SSIZE_T cchSrc, char *dest, s
                 return 0;
             }
             *dest++ = 0xE0 | (wch >> 12);
-            *dest++ = 0x80 | (wch >> 6)&0x3F;
+            *dest++ = 0x80 | ((wch >> 6)&0x3F);
             *dest++ = 0x80 | (wch &0x3F);
         }
         else if (wch < 0xDC00) // 65536 to end of Unicode: 4 bytes
@@ -832,9 +832,9 @@ size_t SystemLocale::Utf8From16( const WCHAR *src, SSIZE_T cchSrc, char *dest, s
                 return 0;
             }
             *dest++ = 0xF0 | (wch >> 18);
-            *dest++ = 0x80 | (wch >>12)&0x3F;
-            *dest++ = 0x80 | (wch >> 6)&0x3F;
-            *dest++ = 0x80 | wch&0x3F;
+            *dest++ = 0x80 | ((wch >>12)&0x3F);
+            *dest++ = 0x80 | ((wch >> 6)&0x3F);
+            *dest++ = 0x80 | (wch&0x3F);
         }
         else // unexpected trail surrogate
         {
@@ -933,7 +933,7 @@ size_t SystemLocale::Utf8From16Strict( const WCHAR *src, SSIZE_T cchSrc, char *d
                 return 0;
             }
             *dest++ = 0xE0 | (wch >> 12);
-            *dest++ = 0x80 | (wch >> 6)&0x3F;
+            *dest++ = 0x80 | ((wch >> 6)&0x3F);
             *dest++ = 0x80 | (wch &0x3F);
         }
         else if (wch < 0xDC00) // 65536 to end of Unicode: 4 bytes
@@ -964,9 +964,9 @@ size_t SystemLocale::Utf8From16Strict( const WCHAR *src, SSIZE_T cchSrc, char *d
                 return 0;
             }
             *dest++ = 0xF0 | (wch >> 18);
-            *dest++ = 0x80 | (wch >>12)&0x3F;
-            *dest++ = 0x80 | (wch >> 6)&0x3F;
-            *dest++ = 0x80 | wch&0x3F;
+            *dest++ = 0x80 | ((wch >>12)&0x3F);
+            *dest++ = 0x80 | ((wch >> 6)&0x3F);
+            *dest++ = 0x80 | (wch&0x3F);
         }
         else // unexpected trail surrogate
         {

--- a/source/sqlsrv/conn.cpp
+++ b/source/sqlsrv/conn.cpp
@@ -1393,7 +1393,10 @@ int get_conn_option_key( _Inout_ sqlsrv_context& ctx, _In_ zend_string* key, _In
 
                     break;
                 }
-            }
+                case CONN_ATTR_INVALID:
+                    SQLSRV_ASSERT(false, "Should not have reached CONN_ATTR_INVALID.");
+                    break;
+             }
 
             return SS_CONN_OPTS[i].conn_option_key;
         }

--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -271,7 +271,7 @@ zend_module_entry g_sqlsrv_module_entry =
 
 PHP_MINIT_FUNCTION(sqlsrv)
 {
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( type );
 
     core_sqlsrv_register_severity_checker(ss_severity_check);
 
@@ -630,8 +630,8 @@ PHP_MSHUTDOWN_FUNCTION(sqlsrv)
 
 PHP_RINIT_FUNCTION(sqlsrv)
 {
-    SQLSRV_UNUSED( module_number );
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( module_number );
+    // SQLSRV_UNUSED( type );
 
 #if defined(ZTS) 
     ZEND_TSRMLS_CACHE_UPDATE();
@@ -690,8 +690,8 @@ PHP_RINIT_FUNCTION(sqlsrv)
 
 PHP_RSHUTDOWN_FUNCTION(sqlsrv)
 {
-    SQLSRV_UNUSED( module_number );
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( module_number );
+    // SQLSRV_UNUSED( type );
 
     LOG_FUNCTION( "PHP_RSHUTDOWN for php_sqlsrv" );
     reset_errors();

--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -596,7 +596,7 @@ void sqlsrv_encoding_dtor( _Inout_ zval* elem ) {
 
 PHP_MSHUTDOWN_FUNCTION(sqlsrv)
 {
-    SQLSRV_UNUSED( type );
+    // SQLSRV_UNUSED( type );
 	
     UNREGISTER_INI_ENTRIES();
 

--- a/source/sqlsrv/php_sqlsrv_int.h
+++ b/source/sqlsrv/php_sqlsrv_int.h
@@ -360,7 +360,7 @@ namespace ss {
 template <typename H>
 inline H* process_params( INTERNAL_FUNCTION_PARAMETERS, _In_ char const* param_spec, _In_ const char* calling_func, _In_ size_t param_count, ... )
 {
-    SQLSRV_UNUSED( return_value );
+    // SQLSRV_UNUSED( return_value );
 
     zval* rsrc;
     H* h = NULL;

--- a/source/sqlsrv/php_sqlsrv_int.h
+++ b/source/sqlsrv/php_sqlsrv_int.h
@@ -212,7 +212,7 @@ enum SS_ERROR_CODES {
 
 extern ss_error SS_ERRORS[];
 
-bool ss_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_error_code, _In_ bool warning, _In_opt_ va_list* print_args );
+bool ss_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_error_code, _In_ int warning, _In_opt_ va_list* print_args );
 
 // convert from the default encoding specified by the "CharacterSet"
 // connection option to UTF-16.  mbcs_len and utf16_len are sizes in
@@ -258,7 +258,7 @@ inline void reset_errors( void )
 }
 
 #define THROW_SS_ERROR( ctx, error_code, ... ) \
-    (void)call_error_handler( ctx, error_code, false /*warning*/, ## __VA_ARGS__ ); \
+    (void)call_error_handler( ctx, error_code, 0 /*warning*/, ## __VA_ARGS__ ); \
     throw ss::SSException();
 
 

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -506,7 +506,7 @@ bool ss_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_err
 
 PHP_FUNCTION( sqlsrv_errors )
 {
-    SQLSRV_UNUSED( execute_data );
+    // SQLSRV_UNUSED( execute_data );
 
     zend_long flags = SQLSRV_ERR_ALL;
 
@@ -557,7 +557,7 @@ PHP_FUNCTION( sqlsrv_errors )
 
 PHP_FUNCTION( sqlsrv_configure )
 {
-    SQLSRV_UNUSED( execute_data );
+    // SQLSRV_UNUSED( execute_data );
 
     LOG_FUNCTION( "sqlsrv_configure" );
 
@@ -680,7 +680,7 @@ PHP_FUNCTION( sqlsrv_configure )
 
 PHP_FUNCTION( sqlsrv_get_config )
 {
-    SQLSRV_UNUSED( execute_data );
+    // SQLSRV_UNUSED( execute_data );
 
     char* option = NULL;
     size_t option_len;

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -37,7 +37,7 @@ void copy_error_to_zval( _Inout_ zval* error_z, _In_ sqlsrv_error_const* error, 
                                 _In_ bool warning );
 bool ignore_warning( _In_ char* sql_state, _In_ int native_code );
 bool handle_errors_and_warnings( _Inout_ sqlsrv_context& ctx, _Inout_ zval* reported_chain, _Inout_ zval* ignored_chain, _In_ logging_severity log_severity, 
-                                 _In_ unsigned int sqlsrv_error_code, _In_ bool warning, _In_opt_ va_list* print_args );
+                                 _In_ unsigned int sqlsrv_error_code, _In_ int warning, _In_opt_ va_list* print_args );
 
 int  sqlsrv_merge_zend_hash_dtor( _Inout_ zval* dest );
 bool sqlsrv_merge_zend_hash( _Inout_ zval* dest_z, zval const* src_z );
@@ -456,7 +456,7 @@ bool ss_severity_check(_In_ unsigned int severity)
     return ((severity & SQLSRV_G(log_severity)) && (SQLSRV_G(current_subsystem) & SQLSRV_G(log_subsystems)));
 }
 
-bool ss_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_error_code, _In_ bool warning, _In_opt_ va_list* print_args )
+bool ss_error_handler( _Inout_ sqlsrv_context& ctx, _In_ unsigned int sqlsrv_error_code, _In_ int warning, _In_opt_ va_list* print_args )
 {
     logging_severity severity = SEV_ERROR;
     if( warning && !SQLSRV_G( warnings_return_as_errors )) {
@@ -821,7 +821,7 @@ void copy_error_to_zval( _Inout_ zval* error_z, _In_ sqlsrv_error_const* error, 
 }
 
 bool handle_errors_and_warnings( _Inout_ sqlsrv_context& ctx, _Inout_ zval* reported_chain, _Inout_ zval* ignored_chain, _In_ logging_severity log_severity, 
-                                 _In_ unsigned int sqlsrv_error_code, _In_ bool warning, _In_opt_ va_list* print_args )
+                                 _In_ unsigned int sqlsrv_error_code, _In_ int warning, _In_opt_ va_list* print_args )
 {
     bool result = true;
     bool errors_ignored = false;


### PR DESCRIPTION
To deal with this warning in Mac:
`warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs] va_start( print_params, warning );`, 

change `bool warning` to `int warning`. 

Concerning va_list and the ellipsis, the rightmost argument and all unnamed ones are subjects for default argument promotion. If a real argument’s type is char, short (with or without a sign) or float (in the above case, a bool), the corresponding parameter must be treated as int, int (with or without a sign) or double. 

Otherwise – undefined behavior [C11 7.16.1.1./2].