### PR TITLE
Removed MACOSX_DEPLOYMENT_TARGET from config

### DIFF
--- a/source/pdo_sqlsrv/config.m4
+++ b/source/pdo_sqlsrv/config.m4
@@ -79,7 +79,6 @@ if test "$PHP_PDO_SQLSRV" != "no"; then
   HOST_OS_ARCH=`uname`
   if test "${HOST_OS_ARCH}" = "Darwin"; then
     PDO_SQLSRV_SHARED_LIBADD="$PDO_SQLSRV_SHARED_LIBADD -Wl,-bind_at_load"
-    MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion`
   else
     PDO_SQLSRV_SHARED_LIBADD="$PDO_SQLSRV_SHARED_LIBADD -Wl,-z,now"
     IS_ALPINE_1=`uname -a | cut -f 4 -d ' ' | cut -f 2 -d '-'`

--- a/source/sqlsrv/config.m4
+++ b/source/sqlsrv/config.m4
@@ -59,7 +59,6 @@ if test "$PHP_SQLSRV" != "no"; then
   HOST_OS_ARCH=`uname`
   if test "${HOST_OS_ARCH}" = "Darwin"; then
     SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-bind_at_load"
-    MACOSX_DEPLOYMENT_TARGET=`sw_vers -productVersion`
   else
     SQLSRV_SHARED_LIBADD="$SQLSRV_SHARED_LIBADD -Wl,-z,now"
     IS_ALPINE_1=`uname -a | cut -f 4 -d ' ' | cut -f 2 -d '-'`


### PR DESCRIPTION
This is no longer required
Related to this [commit](https://github.com/microsoft/msphpsql/commit/f4ae5e1e4c276322c2b3811d0c63cb80d3419afb) 

This fixes the linker issue in #1213 