### PR TITLE
Use lower-case object names in PDO::lastInsertId($name)

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -34,7 +34,7 @@ namespace {
 
 const char LAST_INSERT_ID_QUERY[] = "SELECT @@IDENTITY;";
 const size_t LAST_INSERT_ID_BUFF_LEN = 50;    // size of the buffer to hold the string value of the last inserted id, which may be an int, bigint, decimal(p,0) or numeric(p,0)
-const char SEQUENCE_CURRENT_VALUE_QUERY[] = "SELECT CURRENT_VALUE FROM SYS.SEQUENCES WHERE NAME=%s";
+const char SEQUENCE_CURRENT_VALUE_QUERY[] = "SELECT current_value FROM sys.sequences WHERE name=%s";
 const int LAST_INSERT_ID_QUERY_MAX_LEN = sizeof( SEQUENCE_CURRENT_VALUE_QUERY ) + SQL_MAX_SQLSERVERNAME + 2; // include the quotes
 
 // List of PDO supported connection options.


### PR DESCRIPTION
Closes #1244.

There are existing functional tests that might cover this case, e.g.: https://github.com/microsoft/msphpsql/blob/00de4738ce214666292a69f7786ff7f2c083f86e/test/functional/pdo_sqlsrv/pdo_278_lastinsertid_seq.phpt#L53-L54

But the issue is only reproducible with a certain server configuration which cannot be specified at the connection level. Please let me know if you have a suggestion for a test.