### PR TITLE
Simplified implementations of last insert id and quote

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1362,13 +1362,13 @@ char * pdo_sqlsrv_dbh_last_id( _Inout_ pdo_dbh_t *dbh, _In_z_ const char *name, 
 
     char    idSTR[LAST_INSERT_ID_BUFF_LEN] = { '\0' };
     char*   str = NULL;
-    SQLLEN cbID = 0;
+    SQLLEN  cbID = 0;
 
     try {
 
         char last_insert_id_query[LAST_INSERT_ID_QUERY_MAX_LEN] = {'\0'};
         if( name == NULL ) {
-            strcpy_s( last_insert_id_query, sizeof( last_insert_id_query ), LAST_INSERT_ID_QUERY );
+            strcpy_s(last_insert_id_query, sizeof(last_insert_id_query), LAST_INSERT_ID_QUERY);
         }
         else {
             snprintf(last_insert_id_query, LAST_INSERT_ID_QUERY_MAX_LEN, SEQUENCE_CURRENT_VALUE_QUERY, name);
@@ -1402,13 +1402,8 @@ char * pdo_sqlsrv_dbh_last_id( _Inout_ pdo_dbh_t *dbh, _In_z_ const char *name, 
         }
 
         driver_stmt->~sqlsrv_stmt();
-
-        *len = static_cast<size_t>(cbID);
-        str = reinterpret_cast<char*>(sqlsrv_malloc(cbID, sizeof(char), 1));     // include space for null terminator
-        strcpy_s(str, cbID + 1, idSTR);
     }
     catch( core::CoreException& ) {
-
         // copy any errors on the statement to the connection so that the user sees them, since the statement is released
         // before this method returns
         strcpy_s( dbh->error_code, sizeof( dbh->error_code ),
@@ -1418,9 +1413,8 @@ char * pdo_sqlsrv_dbh_last_id( _Inout_ pdo_dbh_t *dbh, _In_z_ const char *name, 
         if( driver_stmt ) {
             driver_stmt->~sqlsrv_stmt();
         }
-
         *len = 0;
-        char * str = reinterpret_cast<char*>(sqlsrv_malloc(0, sizeof(char), 1));     // include space for null terminator
+        str = reinterpret_cast<char*>(sqlsrv_malloc(0, sizeof(char), 1));     // return an empty string with a null terminator
         str[0] = '\0';
         return str;
     }
@@ -1428,6 +1422,10 @@ char * pdo_sqlsrv_dbh_last_id( _Inout_ pdo_dbh_t *dbh, _In_z_ const char *name, 
     // restore error handling to its previous mode
     dbh->error_mode = prev_err_mode;
 
+    // copy the last ID string and return it
+    *len = static_cast<size_t>(cbID);
+    str = reinterpret_cast<char*>(sqlsrv_malloc(cbID, sizeof(char), 1));     // include space for null terminator
+    strcpy_s(str, cbID + 1, idSTR);
     return str;
 }
 

--- a/test/functional/pdo_sqlsrv/pdo_140_emulate_prepare_pos_placehodlers.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_140_emulate_prepare_pos_placehodlers.phpt
@@ -21,17 +21,25 @@ try {
     $tbname = "watchdog";
     createTable( $cnn, $tbname, array( "system_encoding" => "nvarchar(128)", "utf8_encoding" => "nvarchar(128)", "binary_encoding" => "varbinary(max)"));
 
+    $query = <<<EOF
+INSERT INTO [watchdog] ([system_encoding], [utf8_encoding], [binary_encoding]) VALUES
+(?, ?, ?)
+EOF;
+
+    /** @var MyStatement */
+    $st = $cnn->prepare($query, $pdo_options);
+
     $system_param = 'system encoded string';
     $utf8_param = '가각ácasa';
     $binary_param = fopen('php://memory', 'a');
     fwrite($binary_param, 'asdgasdgasdgsadg');
     rewind($binary_param);
 
-    $inputs = array("system_encoding" => $system_param,
-                    "utf8_encoding" => new BindParamOp( 2, $utf8_param, "PDO::PARAM_STR", 0, "PDO::SQLSRV_ENCODING_UTF8" ),
-                    "binary_encoding" => new BindParamOp( 3, $binary_param, "PDO::PARAM_LOB", 0, "PDO::SQLSRV_ENCODING_BINARY" ));
+    $st->bindParam(1, $system_param, PDO::PARAM_STR);
+    $st->bindParam(2, $utf8_param, PDO::PARAM_STR, 0, PDO::SQLSRV_ENCODING_UTF8);
+    $st->bindParam(3, $binary_param, PDO::PARAM_LOB, 0, PDO::SQLSRV_ENCODING_BINARY);
 
-    insertRow($cnn, $tbname, $inputs, "prepareBindParam");
+    $st->execute();
 
     $data = selectAll($cnn, $tbname);
     var_dump($data);


### PR DESCRIPTION
The `name` column of `sys.sequences` is of type `sysname`, which is [functionally equivalent to nvarchar(128)](https://docs.microsoft.com/previous-versions/sql/sql-server-2008-r2/ms191240(v=sql.105)?redirectedfrom=MSDN#sysname).