### PR TITLE
Fix warning compiling core_stmt.cpp

### DIFF
--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -3101,7 +3101,7 @@ void sqlsrv_param_tvp::process_param(_Inout_ sqlsrv_stmt* stmt, _Inout_ zval* pa
         column_size = num_rows;
         
         buffer = NULL;
-        buffer_length = NULL;
+        buffer_length = 0;
         strlen_or_indptr = (num_columns == 0)? SQL_DEFAULT_PARAM : SQL_DATA_AT_EXEC;
     } else {
         // This is one of the constituent columns of the table-valued parameter


### PR DESCRIPTION
Let's fix this compilation warning:

```
source/sqlsrv/shared/core_stmt.cpp:3104:25: warning: converting to non-pointer type 'long int' from NULL [-Wconversion-null]
         buffer_length = NULL;
                         ^~~~
```