### PR TITLE
Changed return value for PDO::lastInsertId for 8.1+

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1616,7 +1616,7 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
         str[0] = '\0';
         return str;
 #else
-        return NULL;
+        return ZSTR_EMPTY_ALLOC();
 #endif
     }
 

--- a/test/functional/pdo_sqlsrv/pdo_lastInsertId.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_lastInsertId.phpt
@@ -40,7 +40,7 @@ try {
 
 
 ?>
---EXPECTREGEX--
-string\(3\) "200"
-string\(3\) "102"
-(string\(0\) ""|bool\(false\))
+--EXPECT--
+string(3) "200"
+string(3) "102"
+string(0) ""


### PR DESCRIPTION
In case of exception, when running against php8.1 RC, returning `NULL`  throws an exception. Changed to return an empty zend_string instead.
Related to the recent fix in #1330 
