### PR TITLE
Fixed ActiveDirectoryMsi Authentication behavior when specified UID

### DIFF
--- a/source/shared/core_conn.cpp
+++ b/source/shared/core_conn.cpp
@@ -676,8 +676,8 @@ void build_connection_string_and_set_conn_attr( _Inout_ sqlsrv_conn* conn, _Inou
 
     try {
         // Since connection options access token and authentication cannot coexist, check if both of them are used.
-        // If access token is specified, check UID and�PWD as well.
-        // No need to check the keyword Trusted_Connection�because it is not among the acceptable options for SQLSRV drivers
+        // If access token is specified, check UID and PWD as well.
+        // No need to check the keyword Trusted_Connection because it is not among the acceptable options for SQLSRV drivers
         if (zend_hash_index_exists(options, SQLSRV_CONN_OPTION_ACCESS_TOKEN)) {
             bool invalidOptions = false;
 

--- a/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
@@ -83,6 +83,7 @@ require_once('MsSetup.inc');
 
 // Make a connection to an invalid server
 connectInvalidServer();
+connectInvalidServerWithUser();
 
 echo "Done\n";
 ?>

--- a/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
@@ -48,6 +48,37 @@ function connectInvalidServer()
     }
 }
 
+function connectInvalidServerWithUser()
+{
+    global $server, $driver, $uid, $pwd;
+    
+    try {
+        $conn = new PDO("sqlsrv:server = $server; driver=$driver;", $uid, $pwd);
+        
+        $msodbcsqlVer = $conn->getAttribute(PDO::ATTR_CLIENT_VERSION)["DriverVer"];
+        $version = explode(".", $msodbcsqlVer);
+
+        if ($version[0] < 17 || $version[1] < 3) {
+            //skip the rest of this test, which requires ODBC driver 17.3 or above
+            return;
+        }
+        unset($conn);
+
+        // Try connecting to an invalid server, should get an exception from ODBC
+        $connectionInfo = "Authentication = ActiveDirectoryMsi;";
+        $user = "user";
+        $testCase = 'invalidServer';
+        try {
+            $conn = new PDO("sqlsrv:server = invalidServer; $connectionInfo", $user, null);
+            echo $message . $testCase . PHP_EOL;
+        } catch(PDOException $e) {
+            // TODO: check the exception message here
+        }
+    } catch(PDOException $e) {
+        print_r($e->getMessage());
+    }
+}
+
 require_once('MsSetup.inc');
 
 // Make a connection to an invalid server


### PR DESCRIPTION
In case of Authentication = ActiveDirectoryMsi, UID may be specified when using user-managed identity.
This fix is for ActiveDirectoryMsi to use the specified UID.

[MS Doc - Connect Using Azure Active Directory Authentication - Using the user-assigned managed identity with PDO_SQLSRV driver](https://docs.microsoft.com/en-us/sql/connect/php/azure-active-directory?view=sql-server-ver15#using-the-user-assigned-managed-identity-with-pdo_sqlsrv-driver)

