### PR TITLE
Update bvt tests for PHP 8.2

### DIFF
--- a/buildscripts/buildtools.py
+++ b/buildscripts/buildtools.py
@@ -321,7 +321,7 @@ class BuildUtil(object):
             else:       # pdo_sqlsrv
                 cmd_line = ' --enable-pdo --with-pdo-sqlsrv=shared ' + cmd_line
                 
-        cmd_line = 'cscript configure.js --disable-all --enable-cli --enable-cgi --enable-json --enable-embed' + cmd_line
+        cmd_line = 'cscript configure.js --disable-all --enable-cli --enable-cgi --enable-json --enable-embed --enable-mbstring' + cmd_line
         if self.thread == 'nts':
             cmd_line = cmd_line + ' --disable-zts'
         return cmd_line

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetch.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetch.phpt
@@ -8,9 +8,13 @@ fetch with all fetch styles
    $conn = new PDO( "sqlsrv:server=$server ; Database = $databaseName", "$uid", "$pwd");
 
    print( "\n---------- PDO::FETCH_CLASS -------------\n" );
-   $stmt = $conn->query( "select * from HumanResources.Department order by GroupName" );
+   $stmt = $conn->query( "select DepartmentID, Name, GroupName from HumanResources.Department order by GroupName" );
 
    class cc {
+      public $DepartmentID;
+      public $Name;
+      public $GroupName;
+
       function __construct( $arg ) {
          echo "$arg";
       }
@@ -26,7 +30,7 @@ fetch with all fetch styles
    }
 
    print( "\n---------- PDO::FETCH_INTO -------------\n" );
-   $stmt = $conn->query( "select * from HumanResources.Department order by GroupName" );
+   $stmt = $conn->query( "select DepartmentID, Name, GroupName from HumanResources.Department order by GroupName" );
    $c_obj = new cc( '' );
 
    $stmt->setFetchMode(PDO::FETCH_INTO, $c_obj);

--- a/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchAll.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdoStatement_fetchAll.phpt
@@ -25,6 +25,10 @@ fetches the rows in a result set in an array
    print "\n-----------\n";
 
    class cc {
+      public $ContactTypeID;
+      public $Name;
+      public $ModifiedDate;
+
       function __construct( $arg ) {
          echo "$arg\n";
       }
@@ -34,7 +38,7 @@ fetches the rows in a result set in an array
       }
    };
 
-   $stmt = $conn->query( 'SELECT TOP(2) * FROM Person.ContactType' );
+   $stmt = $conn->query( 'SELECT TOP(2) ContactTypeID, Name, ModifiedDate FROM Person.ContactType' );
    $all = $stmt->fetchAll( PDO::FETCH_CLASS, 'cc', array( 'Hi!' ));
    var_dump( $all );
    

--- a/test/bvt/pdo_sqlsrv/msdn_pdo_query.phpt
+++ b/test/bvt/pdo_sqlsrv/msdn_pdo_query.phpt
@@ -26,9 +26,13 @@ while ( $row = $stmt->fetch() ){
 }
 
 echo "\n........ query with a new class ............\n";
-$query = 'select * from HumanResources.Department order by GroupName';
+$query = 'select DepartmentID, Name, GroupName from HumanResources.Department order by GroupName';
 // query with a class
 class cc {
+      public $DepartmentID;
+      public $Name;
+      public $GroupName;
+
    function __construct( $arg ) {
       echo "$arg";
    }

--- a/test/bvt/sqlsrv/msdn_sqlsrv_connect_utf8.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_connect_utf8.phpt
@@ -25,7 +25,7 @@ $tsql1 = "UPDATE Production.ProductReview
 // 
 $reviewID = 3;
 
-$comments = utf8_encode("testing 1, 2, 3, 4.  Testing.");
+$comments = mb_convert_encoding("testing 1, 2, 3, 4.  Testing.", 'ISO-8859-1', 'UTF-8');
 $params1 = array(
                   array( $comments, null ),
                   array( $reviewID, null )

--- a/test/bvt/sqlsrv/msdn_sqlsrv_fetch_object_2.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_fetch_object_2.phpt
@@ -7,6 +7,8 @@ retrieves each row of a result set as an instance of the Product class defined i
 /* Define the Product class. */
 class Product
 {
+
+
      /* Constructor */
      public function ProductConstruct($ID)
      {
@@ -17,6 +19,8 @@ class Product
      public $StockedQty;
      public $SafetyStockLevel;
      private $UnitPrice;
+     public $Name;
+     public $Color;
      function getPrice()
      {
           return $this->UnitPrice;

--- a/test/bvt/sqlsrv/msdn_sqlsrv_query_utf8.phpt
+++ b/test/bvt/sqlsrv/msdn_sqlsrv_query_utf8.phpt
@@ -27,7 +27,7 @@ $tsql1 = "UPDATE Production.ProductReview
 // utf8_encode to simulate an application that uses UTF-8 encoded data. 
 // 
 $reviewID = 3;
-$comments = utf8_encode("testing");
+$comments = mb_convert_encoding("testing", 'ISO-8859-1', 'UTF-8');
 $params1 = array(
                   array($comments,
                         SQLSRV_PARAM_IN,


### PR DESCRIPTION
1. Declare the property used in tests.
2. Replace utf8_encode() with mb_convert_encoding().