### PR TITLE
Fixed error when using PDO::ATTR_STRINGIFY_FETCHES

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1323,14 +1323,6 @@ bool pdo_sqlsrv_dbh_set_attr(_Inout_ pdo_dbh_t *dbh, _In_ zend_long attr, _Inout
             break;
 #endif
 
-#if (PHP_VERSION_ID >= 80122 && PHP_VERSION_ID < 80200) || PHP_VERSION_ID >= 80209
-            case PDO_ATTR_STRINGIFY_FETCHES:
-            {
-                // do nothing
-            }
-            break;
-#endif
-
             // Not supported
             case PDO_ATTR_FETCH_TABLE_NAMES:
             case PDO_ATTR_FETCH_CATALOG_NAMES:

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1323,6 +1323,14 @@ bool pdo_sqlsrv_dbh_set_attr(_Inout_ pdo_dbh_t *dbh, _In_ zend_long attr, _Inout
             break;
 #endif
 
+#if (PHP_VERSION_ID >= 80122 && PHP_VERSION_ID < 80200) || PHP_VERSION_ID >= 80209
+            case PDO_ATTR_STRINGIFY_FETCHES:
+            {
+                // do nothing
+            }
+            break;
+#endif
+
             // Not supported
             case PDO_ATTR_FETCH_TABLE_NAMES:
             case PDO_ATTR_FETCH_CATALOG_NAMES:


### PR DESCRIPTION
This fixes the issue reported here.

https://github.com/laravel/framework/issues/47937


Fixes for errors caused by PDO changes in php8.1.22 and 8.2.9.


test code
```
<?php

// my env
$pdo = new PDO('sqlsrv:server=mssql-server;database=test;', 'test_user', 'p@ssw0rd');
$pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
```