### PR TITLE
Pdo connection quote fix

### DIFF
--- a/buildscripts/buildtools.py
+++ b/buildscripts/buildtools.py
@@ -92,7 +92,7 @@ class BuildUtil(object):
         if vc == '15':
             return 'vc15'
         else: # For VS2019, it's 'vs' instead of 'vc'
-            return 'vs16'
+            return 'vs17'
         
     def compiler_version(self, sdk_dir):
         """Return the appropriate compiler version based on PHP version."""
@@ -100,7 +100,7 @@ class BuildUtil(object):
             VC = 'vc15'
             version = self.version_label()
             if version[0] == '8':     # Compiler version for PHP 8.0 or above
-                VC = 'vs16'
+                VC = 'vs17'
             self.vc = VC
             print('Compiler: ' + self.vc)
         return self.vc

--- a/test/functional/pdo_sqlsrv/PDO29_ConnInterface.phpt
+++ b/test/functional/pdo_sqlsrv/PDO29_ConnInterface.phpt
@@ -53,6 +53,13 @@ function CheckInterface($conn)
         unset($expected['__wakeup']);
         unset($expected['__sleep']);
     }
+
+//change for 8.4
+if ($phpver >= '8.4') {
+    // PHP 8.4 introduced PDO::connect()
+    $expected['connect'] = true;
+}
+	
     
     $classname = get_class($conn);
     $methods = get_class_methods($classname);

--- a/test/functional/pdo_sqlsrv/PDO29_ConnInterface.phpt
+++ b/test/functional/pdo_sqlsrv/PDO29_ConnInterface.phpt
@@ -56,7 +56,7 @@ function CheckInterface($conn)
 
 //change for 8.4
 if ($phpver >= '8.4') {
-    // PHP 8.4 introduced PDO::connect()
+    // PHP 8.4 introduced PDO::connect(). UPDATED
     $expected['connect'] = true;
 }
 	

--- a/test/functional/pdo_sqlsrv/PDO29_ConnInterface.phpt
+++ b/test/functional/pdo_sqlsrv/PDO29_ConnInterface.phpt
@@ -56,7 +56,7 @@ function CheckInterface($conn)
 
 //change for 8.4
 if ($phpver >= '8.4') {
-    // PHP 8.4 introduced PDO::connect(). UPDATED
+    // PHP 8.4 introduced PDO::connect(). 8.4+
     $expected['connect'] = true;
 }
 	

--- a/test/functional/pdo_sqlsrv/pdo_connection_quote.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_connection_quote.phpt
@@ -31,7 +31,7 @@ try {
             echo("Empty query was expected to fail!\n");
         } catch (ValueError $ve) {
             // PHP 8.3 says "cannot be empty", PHP 8.4 says "must not be empty"
-            // We use * wildcards to match both.
+            // We use * wildcards to match both. UPDATED
             $error = '*PDO::query(): Argument #1 ($query) * be empty';
             if (!fnmatch($error, $ve->getMessage())) {
                 var_dump($ve->getMessage());

--- a/test/functional/pdo_sqlsrv/pdo_connection_quote.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_connection_quote.phpt
@@ -30,7 +30,9 @@ try {
             $stmt = $conn->query("");
             echo("Empty query was expected to fail!\n");
         } catch (ValueError $ve) {
-            $error = '*PDO::query(): Argument #1 ($query) cannot be empty';
+            // PHP 8.3 says "cannot be empty", PHP 8.4 says "must not be empty"
+            // We use * wildcards to match both.
+            $error = '*PDO::query(): Argument #1 ($query) * be empty';
             if (!fnmatch($error, $ve->getMessage())) {
                 var_dump($ve->getMessage());
             }


### PR DESCRIPTION
PDO::query empty-string behavior across PHP versions.
