### PR TITLE
Adding beta version

### DIFF
--- a/source/shared/version.h
+++ b/source/shared/version.h
@@ -31,7 +31,7 @@
 #define SQLVERSION_BUILD 0
 
 // For previews, set this constant to 1, 2 and so on. Otherwise, set it to 0
-#define PREVIEW 0
+#define PREVIEW 1
 #define SEMVER_PRERELEASE
 
 // Semantic versioning build metadata, build meta data is not counted in precedence order.


### PR DESCRIPTION
This pull request makes a minor update to the versioning configuration by marking the current build as a preview release.

* Versioning:
  * Set the `PREVIEW` constant to `1` in `source/shared/version.h`, indicating this build is now a preview version.