### PR TITLE
Remove error2 reference from failure block

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1256,4 +1256,3 @@ jobs:
       sqllocaldb stop MSSQLLocalDB
     displayName: 'Cleanup LocalDB'
     condition: always()
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
     macOS_sqlsrv_db: 'macos_sqlsrv_testdb'
     macOS_pdo_sqlsrv_db: 'macos_pdo_sqlsrv_testdb'
     REPO_ROOT: $(Build.SourcesDirectory)
+  timeoutInMinutes: 90
   steps:
   - checkout: self
     clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
     macOS_sqlsrv_db: 'macos_sqlsrv_testdb'
     macOS_pdo_sqlsrv_db: 'macos_pdo_sqlsrv_testdb'
     REPO_ROOT: $(Build.SourcesDirectory)
-  timeoutInMinutes: 90
   steps:
   - checkout: self
     clean: true
@@ -1257,3 +1256,4 @@ jobs:
       sqllocaldb stop MSSQLLocalDB
     displayName: 'Cleanup LocalDB'
     condition: always()
+

--- a/test/functional/pdo_sqlsrv/pdo_connection_quote.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_connection_quote.phpt
@@ -33,8 +33,7 @@ try {
             // PHP 8.3 says "cannot be empty", PHP 8.4 says "must not be empty"
             // We use * wildcards to match both.
             $error = '*PDO::query(): Argument #1 ($query) * be empty';
-            if (!fnmatch($error, $ve->getMessage()) &&
-                !fnmatch($error2, $ve->getMessage())) {
+            if (!fnmatch($error, $ve->getMessage())) {
                 var_dump($ve->getMessage());
             }
         }


### PR DESCRIPTION
Remove a lingering reference to the error2 variable, which was previously removed in #1561.

Also increase the macOS job timeout from 60 to 90 minutes. The job takes about 60 minutes and times out intermittently without the higher timeout.