### PR TITLE
FIX: Resolve C4146 compiler warning for SDL compliance

### DIFF
--- a/source/pdo_sqlsrv/config.w32
+++ b/source/pdo_sqlsrv/config.w32
@@ -36,7 +36,6 @@ if( PHP_PDO_SQLSRV != "no" ) {
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/Zi" );
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/ZH:SHA_256 /sdl /W3" );
             ADD_FLAG( "LDFLAGS_PDO_SQLSRV", "/CETCOMPAT" );
-            ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/wd4146" );
             if (PHP_DEBUG != "yes") ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/guard:cf /O2" );
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/D ZEND_WIN32_FORCE_INLINE" );
             if (VCVERS >= 1913) {

--- a/source/pdo_sqlsrv/config.w32
+++ b/source/pdo_sqlsrv/config.w32
@@ -34,7 +34,7 @@ if( PHP_PDO_SQLSRV != "no" ) {
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/EHsc" );
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/GS" );
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/Zi" );
-            ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/ZH:SHA_256 /sdl /W3" );
+            ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/ZH:SHA_256 /sdl /W4 /WX" );
             ADD_FLAG( "LDFLAGS_PDO_SQLSRV", "/CETCOMPAT" );
             if (PHP_DEBUG != "yes") ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/guard:cf /O2" );
             ADD_FLAG( "CFLAGS_PDO_SQLSRV", "/D ZEND_WIN32_FORCE_INLINE" );

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -690,7 +690,7 @@ int pdo_sqlsrv_db_handle_factory( _Inout_ pdo_dbh_t *dbh, _In_opt_ zval *driver_
 
     // set the driver_data and methods to complete creation of the PDO object
     dbh->driver_data = conn;
-    dbh->error_mode = prev_err_mode;    // reset the error mode
+    dbh->error_mode = static_cast<decltype(dbh->error_mode)>(prev_err_mode);    // reset the error mode
     dbh->alloc_own_columns = 1;         // we do our own memory management for columns
     dbh->native_case = PDO_CASE_NATURAL;// SQL Server supports mixed case types
 
@@ -700,7 +700,7 @@ int pdo_sqlsrv_db_handle_factory( _Inout_ pdo_dbh_t *dbh, _In_opt_ zval *driver_
         if ( Z_TYPE( server_z ) == IS_STRING ) {
             zend_string_release( Z_STR( server_z ));
         }
-        dbh->error_mode = prev_err_mode;    // reset the error mode
+        dbh->error_mode = static_cast<decltype(dbh->error_mode)>(prev_err_mode);    // reset the error mode
         g_pdo_henv_cp->last_error().reset();    // reset the last error; callee will check if last_error exist before freeing it and setting it to NULL
 
         return 0;
@@ -774,8 +774,10 @@ bool pdo_sqlsrv_dbh_prepare(_Inout_ pdo_dbh_t *dbh, _In_ zend_string *sql_zstr, 
     PDO_LOG_DBH_ENTRY;
 
     hash_auto_ptr pdo_stmt_options_ht;
+#if PHP_VERSION_ID < 80100
     sqlsrv_malloc_auto_ptr<char> sql_rewrite;
     size_t sql_rewrite_len = 0;
+#endif
     sqlsrv_malloc_auto_ptr<pdo_sqlsrv_stmt> driver_stmt;
     hash_auto_ptr placeholders;
     sqlsrv_malloc_auto_ptr<sql_string_parser> sql_parser;
@@ -877,7 +879,7 @@ bool pdo_sqlsrv_dbh_prepare(_Inout_ pdo_dbh_t *dbh, _In_ zend_string *sql_zstr, 
                 static_cast<int>(stmt->query_stringlen), placeholders);
 #else
             sql_parser = new (sqlsrv_malloc(sizeof(sql_string_parser))) sql_string_parser(*driver_dbh, ZSTR_VAL(stmt->query_string),
-                ZSTR_LEN(stmt->query_string), placeholders);
+                static_cast<int>(ZSTR_LEN(stmt->query_string)), placeholders);
 #endif
             sql_parser->parse_sql_string();
             driver_stmt->placeholders = placeholders;
@@ -970,8 +972,9 @@ zend_long pdo_sqlsrv_dbh_do(_Inout_ pdo_dbh_t *dbh, _In_ const zend_string *sql)
 #if PHP_VERSION_ID < 80100
         SQLRETURN execReturn = core_sqlsrv_execute(driver_stmt, sql, static_cast<int>(sql_len));
 #else
-        SQLRETURN execReturn = core_sqlsrv_execute(driver_stmt, ZSTR_VAL(sql), ZSTR_LEN(sql));
+        SQLRETURN execReturn = core_sqlsrv_execute(driver_stmt, ZSTR_VAL(sql), static_cast<int>(ZSTR_LEN(sql)));
 #endif
+        (void)execReturn;
         // since the user can give us a compound statement, we return the row count for the last set, and since the row count
         // isn't guaranteed to be valid until all the results have been fetched, we fetch them all first.
 
@@ -1656,7 +1659,7 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
         driver_stmt->~sqlsrv_stmt();
     } catch( core::CoreException& ) {
         // restore error handling to its previous mode
-        dbh->error_mode = prev_err_mode;
+        dbh->error_mode = static_cast<decltype(dbh->error_mode)>(prev_err_mode);
 
         // copy any errors on the statement to the connection so that the user sees them, since the statement is released
         // before this method returns
@@ -1678,7 +1681,7 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
     }
 
     // restore error handling to its previous mode
-    dbh->error_mode = prev_err_mode;
+    dbh->error_mode = static_cast<decltype(dbh->error_mode)>(prev_err_mode);
 
     // copy the last ID string and return it
     str = reinterpret_cast<char*>(sqlsrv_malloc(cbID, sizeof(char), 1));     // include space for null terminator
@@ -1898,7 +1901,7 @@ zend_string* pdo_sqlsrv_dbh_quote(_Inout_ pdo_dbh_t* dbh, _In_ const zend_string
 }
 
 // This method is not implemented by this driver.
-pdo_sqlsrv_function_entry *pdo_sqlsrv_get_driver_methods( _Inout_ pdo_dbh_t *dbh, int kind )
+pdo_sqlsrv_function_entry *pdo_sqlsrv_get_driver_methods( _Inout_ pdo_dbh_t *dbh, int /*kind*/ )
 {
     PDO_RESET_DBH_ERROR;
     PDO_VALIDATE_CONN;
@@ -1909,7 +1912,7 @@ pdo_sqlsrv_function_entry *pdo_sqlsrv_get_driver_methods( _Inout_ pdo_dbh_t *dbh
     // As per documentation, simply return false if the method does not exist
     // https://www.php.net/manual/en/function.is-callable.php
     // But user can call PDO::errorInfo() to check the error message if necessary
-    CHECK_CUSTOM_WARNING_AS_ERROR(true, driver_conn, PDO_SQLSRV_ERROR_FUNCTION_NOT_IMPLEMENTED, NULL);
+    CHECK_CUSTOM_WARNING_AS_ERROR(true, driver_conn, PDO_SQLSRV_ERROR_FUNCTION_NOT_IMPLEMENTED, NULL) {}
 
     return NULL;    // return NULL for PDO to take care of the rest
 }
@@ -2006,7 +2009,7 @@ void validate_stmt_options( _Inout_ sqlsrv_context& ctx, _Inout_ zval* stmt_opti
         if( stmt_options ) {
 
             HashTable* options_ht = Z_ARRVAL_P( stmt_options );
-            size_t int_key = -1;
+            size_t int_key = static_cast<size_t>(-1);
             zend_string *key = NULL;
             zval* data = NULL;
 

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -1921,7 +1921,7 @@ namespace {
 void add_stmt_option_key(_Inout_ sqlsrv_context& ctx, _In_ size_t key, _Inout_ HashTable* options_ht,
                             _Inout_ zval* data)
 {
-    zend_ulong option_key = -1;
+    zend_ulong option_key = 0;
     switch (key) {
 
     case PDO_ATTR_CURSOR:
@@ -1984,7 +1984,7 @@ void add_stmt_option_key(_Inout_ sqlsrv_context& ctx, _In_ size_t key, _Inout_ H
     }
 
     // if a PDO handled option makes it through (such as PDO_ATTR_STATEMENT_CLASS, just skip it
-    if (option_key != -1) {
+    if (option_key != 0) {
         zval_add_ref(data);
         core::sqlsrv_zend_hash_index_update(ctx, options_ht, option_key, data);
     }
@@ -2010,6 +2010,8 @@ void validate_stmt_options( _Inout_ sqlsrv_context& ctx, _Inout_ zval* stmt_opti
             zend_string *key = NULL;
             zval* data = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
             ZEND_HASH_FOREACH_KEY_VAL( options_ht, int_key, key, data ) {
                 int type = HASH_KEY_NON_EXISTENT;
                 type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
@@ -2019,6 +2021,7 @@ void validate_stmt_options( _Inout_ sqlsrv_context& ctx, _Inout_ zval* stmt_opti
 
                 add_stmt_option_key( ctx, int_key, pdo_stmt_options_ht, data );
             } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
         }
     }
     catch( core::CoreException& ) {

--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -151,7 +151,7 @@ struct pdo_encrypt_set_func
         if (found != std::string::npos)
             val_str.erase(found + 1);
 
-        transform(val_str.begin(), val_str.end(), val_str.begin(), ::tolower);
+        transform(val_str.begin(), val_str.end(), val_str.begin(), [](unsigned char c) { return static_cast<char>(::tolower(c)); });
 
         // For backward compatibility, convert true/1 to yes
         std::string attr;

--- a/source/pdo_sqlsrv/pdo_init.cpp
+++ b/source/pdo_sqlsrv/pdo_init.cpp
@@ -116,7 +116,7 @@ void pdo_error_dtor( _Inout_ zval* elem ) {
 
 PHP_MINIT_FUNCTION(pdo_sqlsrv)
 {
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( type );
 
     // our global variables are initialized in the RINIT function
 #if defined(ZTS)
@@ -185,7 +185,7 @@ PHP_MSHUTDOWN_FUNCTION(pdo_sqlsrv)
 {
     try {
 
-        // SQLSRV_UNUSED( type );
+        SQLSRV_UNUSED( type );
 
         UNREGISTER_INI_ENTRIES();
 
@@ -213,8 +213,8 @@ PHP_MSHUTDOWN_FUNCTION(pdo_sqlsrv)
 
 PHP_RINIT_FUNCTION(pdo_sqlsrv)
 {
-    // SQLSRV_UNUSED( module_number );
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( module_number );
+    SQLSRV_UNUSED( type );
 
 #if defined(ZTS) 
     ZEND_TSRMLS_CACHE_UPDATE();
@@ -247,8 +247,8 @@ PHP_RINIT_FUNCTION(pdo_sqlsrv)
 
 PHP_RSHUTDOWN_FUNCTION(pdo_sqlsrv)
 {
-    // SQLSRV_UNUSED( module_number );
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( module_number );
+    SQLSRV_UNUSED( type );
 
     PDO_LOG_NOTICE("pdo_sqlsrv: entering rshutdown");
 

--- a/source/pdo_sqlsrv/pdo_parser.cpp
+++ b/source/pdo_sqlsrv/pdo_parser.cpp
@@ -91,17 +91,17 @@ inline bool string_parser::is_white_space( _In_ char c )
 }
 
 // Discard any trailing white spaces.
-int conn_string_parser::discard_trailing_white_spaces( _In_reads_(len) const char* str, _Inout_ int len )
+int conn_string_parser::discard_trailing_white_spaces( _In_reads_(buf_len) const char* str, _Inout_ int buf_len )
 {
-    const char* end = str + ( len - 1 );
+    const char* end = str + ( buf_len - 1 );
 
-    while(( this->is_white_space( *end ) ) && (len > 0) ) {
+    while(( this->is_white_space( *end ) ) && (buf_len > 0) ) {
 
-        len--;
+        buf_len--;
         end--;
     }
 
-    return len;
+    return buf_len;
 }
 
 // Discard white spaces.
@@ -122,18 +122,18 @@ bool string_parser::discard_white_spaces()
 }
 
 // Add a key-value pair to the hashtable
-void string_parser::add_key_value_pair( _In_reads_(len) const char* value, _In_ int len )
+void string_parser::add_key_value_pair( _In_reads_(val_len) const char* value, _In_ int val_len )
 {
     zval value_z;
     ZVAL_UNDEF( &value_z );
 
-    if( len == 0 ) {
+    if( val_len == 0 ) {
 
         ZVAL_STRINGL( &value_z, "", 0);
     }
     else {
 
-        ZVAL_STRINGL( &value_z, const_cast<char*>( value ), len );
+        ZVAL_STRINGL( &value_z, const_cast<char*>( value ), val_len );
     }
 
     core::sqlsrv_zend_hash_index_update( *ctx, this->element_ht, this->current_key, &value_z );
@@ -155,7 +155,7 @@ void conn_string_parser::validate_key( _In_reads_(key_len) const char *key, _Ino
     for( int i=0; PDO_CONN_OPTS[i].conn_option_key != SQLSRV_CONN_OPTION_INVALID; ++i )
     {
         // discard the null terminator.
-        if( new_len == ( PDO_CONN_OPTS[i].sqlsrv_len - 1 ) && !strncasecmp( key, PDO_CONN_OPTS[i].sqlsrv_name, new_len )) {
+        if( static_cast<size_t>(new_len) == ( PDO_CONN_OPTS[i].sqlsrv_len - 1 ) && !strncasecmp( key, PDO_CONN_OPTS[i].sqlsrv_name, new_len )) {
 
             this->current_key = PDO_CONN_OPTS[i].conn_option_key;
             this->current_key_name = PDO_CONN_OPTS[i].sqlsrv_name;

--- a/source/pdo_sqlsrv/pdo_stmt.cpp
+++ b/source/pdo_sqlsrv/pdo_stmt.cpp
@@ -434,7 +434,7 @@ int pdo_sqlsrv_stmt_describe_col( _Inout_ pdo_stmt_t *stmt, _In_ int colno)
 
     try {
 
-        core_meta_data = core_sqlsrv_field_metadata( reinterpret_cast<sqlsrv_stmt*>( stmt->driver_data ), colno );
+        core_meta_data = core_sqlsrv_field_metadata( reinterpret_cast<sqlsrv_stmt*>( stmt->driver_data ), static_cast<SQLSMALLINT>(colno) );
     }
 
     catch( core::CoreException& ) {
@@ -562,7 +562,7 @@ int pdo_sqlsrv_stmt_execute( _Inout_ pdo_stmt_t *stmt )
             query_len = static_cast<unsigned int>(stmt->active_query_stringlen);
 #else
             query = ZSTR_VAL(stmt->active_query_string);
-            query_len = ZSTR_LEN(stmt->active_query_string);
+            query_len = static_cast<unsigned int>(ZSTR_LEN(stmt->active_query_string));
 #endif
         }
 
@@ -582,7 +582,7 @@ int pdo_sqlsrv_stmt_execute( _Inout_ pdo_stmt_t *stmt )
         else {
             if (driver_stmt->column_count == ACTIVE_NUM_COLS_INVALID) {
                 stmt->column_count = core::SQLNumResultCols( driver_stmt );
-                driver_stmt->column_count = stmt->column_count;
+                driver_stmt->column_count = static_cast<short>(stmt->column_count);
             }
             else {
                 stmt->column_count = driver_stmt->column_count;
@@ -591,7 +591,7 @@ int pdo_sqlsrv_stmt_execute( _Inout_ pdo_stmt_t *stmt )
             if (driver_stmt->row_count == ACTIVE_NUM_ROWS_INVALID) {
                 // return the row count regardless if there are any rows or not
                 stmt->row_count = core::SQLRowCount( driver_stmt );
-                driver_stmt->row_count = stmt->row_count;
+                driver_stmt->row_count = static_cast<long>(stmt->row_count);
             }
             else {
                 stmt->row_count = driver_stmt->row_count;
@@ -716,7 +716,7 @@ int pdo_sqlsrv_stmt_fetch( _Inout_ pdo_stmt_t *stmt, _In_ enum pdo_fetch_orienta
         if( driver_stmt->past_fetch_end || driver_stmt->cursor_type == SQL_CURSOR_DYNAMIC) {
 
             stmt->row_count = core::SQLRowCount( driver_stmt );
-            driver_stmt->row_count = stmt->row_count;
+            driver_stmt->row_count = static_cast<long>(stmt->row_count);
 
             // a row_count of -1 means no rows, but we change it to 0
             if( stmt->row_count == -1 ) {
@@ -763,7 +763,7 @@ int pdo_sqlsrv_stmt_fetch( _Inout_ pdo_stmt_t *stmt, _In_ enum pdo_fetch_orienta
 int pdo_sqlsrv_stmt_get_col_data( _Inout_ pdo_stmt_t *stmt, _In_ int colno,
                                  _Out_writes_bytes_opt_(*len) char **ptr, _Inout_ size_t *len, _Out_opt_ int *caller_frees)
 #else
-int pdo_sqlsrv_stmt_get_col_data(_Inout_ pdo_stmt_t *stmt, _In_ int colno, _Inout_ zval *result_z, _Inout_ enum pdo_param_type *type)
+int pdo_sqlsrv_stmt_get_col_data(_Inout_ pdo_stmt_t *stmt, _In_ int colno, _Inout_ zval *result_z, _Inout_ enum pdo_param_type * /*type*/)
 #endif
 
 {
@@ -864,7 +864,7 @@ int pdo_sqlsrv_stmt_get_col_data(_Inout_ pdo_stmt_t *stmt, _In_ int colno, _Inou
 #else
         SQLLEN len = 0;
         void *ptr = NULL;
-        core_sqlsrv_get_field(driver_stmt, colno, sqlsrv_php_type, false, ptr, &len, true, &sqlsrv_phptype_out);
+        core_sqlsrv_get_field(driver_stmt, static_cast<SQLUSMALLINT>(colno), sqlsrv_php_type, false, ptr, &len, true, &sqlsrv_phptype_out);
         if (ptr) {
             *result_z = convert_to_zval(driver_stmt, sqlsrv_phptype_out, &ptr, len);
         }
@@ -1108,7 +1108,7 @@ int pdo_sqlsrv_stmt_get_col_meta( _Inout_ pdo_stmt_t *stmt, _In_ zend_long colno
         field_meta_data* core_meta_data;
 
         // metadata should have been saved earlier
-        SQLSRV_ASSERT(colno < driver_stmt->current_meta_data.size(), "pdo_sqlsrv_stmt_get_col_meta: Metadata vector out of sync with column numbers");
+        SQLSRV_ASSERT(static_cast<size_t>(colno) < driver_stmt->current_meta_data.size(), "pdo_sqlsrv_stmt_get_col_meta: Metadata vector out of sync with column numbers");
         core_meta_data = driver_stmt->current_meta_data[colno];
 
         // add the following fields: flags, native_type, driver:decl_type, table
@@ -1223,8 +1223,8 @@ int pdo_sqlsrv_stmt_next_rowset( _Inout_ pdo_stmt_t *stmt )
         // return the row count regardless if there are any rows or not
         stmt->row_count = core::SQLRowCount( driver_stmt );
 
-        driver_stmt->column_count = stmt->column_count;
-        driver_stmt->row_count = stmt->row_count;
+        driver_stmt->column_count = static_cast<short>(stmt->column_count);
+        driver_stmt->row_count = static_cast<long>(stmt->row_count);
     }
     catch( core::CoreException& ) {
 
@@ -1454,7 +1454,7 @@ int pdo_sqlsrv_stmt_param_hook( _Inout_ pdo_stmt_t *stmt,
                     }
 
                     // and bind the parameter
-                    core_sqlsrv_bind_param( driver_stmt, static_cast<SQLUSMALLINT>( param->paramno ), direction, &(param->parameter) , php_out_type, encoding,
+                    core_sqlsrv_bind_param( driver_stmt, static_cast<SQLUSMALLINT>( param->paramno ), static_cast<SQLSMALLINT>(direction), &(param->parameter) , php_out_type, encoding,
                                             sql_type, column_size, decimal_digits);
                 }
                 break;
@@ -1491,7 +1491,7 @@ int pdo_sqlsrv_stmt_param_hook( _Inout_ pdo_stmt_t *stmt,
 
 
 // Returns a sqlsrv_phptype for a given SQL Server data type.
-sqlsrv_phptype pdo_sqlsrv_stmt::sql_type_to_php_type( _In_ SQLINTEGER sql_type, _In_ SQLUINTEGER size, _In_ bool prefer_string_over_stream )
+sqlsrv_phptype pdo_sqlsrv_stmt::sql_type_to_php_type( _In_ SQLINTEGER sql_type, _In_ SQLUINTEGER /*size*/, _In_ bool /*prefer_string_over_stream*/ )
 {
     sqlsrv_phptype sqlsrv_phptype;
     int local_encoding = this->encoding();

--- a/source/pdo_sqlsrv/pdo_util.cpp
+++ b/source/pdo_sqlsrv/pdo_util.cpp
@@ -680,7 +680,7 @@ void format_or_get_all_errors(_Inout_ sqlsrv_context& ctx, _In_opt_ unsigned int
     }
     else {
         if(core_sqlsrv_get_odbc_error(ctx, 1, error, SEV_ERROR, true)) {
-            unsigned int rec_number = 2;
+            SQLSMALLINT rec_number = 2;
             sqlsrv_error_auto_ptr err;
             sqlsrv_error *p = error;
 

--- a/source/pdo_sqlsrv/php_pdo_sqlsrv.h
+++ b/source/pdo_sqlsrv/php_pdo_sqlsrv.h
@@ -20,7 +20,17 @@
 //  IN THE SOFTWARE.
 //---------------------------------------------------------------------------------------------------------------------------------
 
+// Suppress warnings from PHP headers that we cannot modify
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4244 4267 4456 4457 4706)
+#endif
+
 #include "php.h"
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 //*********************************************************************************************************************************
 // Global variables

--- a/source/pdo_sqlsrv/php_pdo_sqlsrv_int.h
+++ b/source/pdo_sqlsrv/php_pdo_sqlsrv_int.h
@@ -122,7 +122,7 @@ class string_parser
         inline bool is_eos(void);
         inline bool is_white_space( _In_ char c );
         bool discard_white_spaces(void);
-        void add_key_value_pair( _In_reads_(len) const char* value, _In_ int len );
+        void add_key_value_pair( _In_reads_(val_len) const char* value, _In_ int val_len );
 };
 
 
@@ -146,7 +146,7 @@ class conn_string_parser : private string_parser
 
     private:
         const char* current_key_name;
-        int discard_trailing_white_spaces( _In_reads_(len) const char* str, _Inout_ int len );
+        int discard_trailing_white_spaces( _In_reads_(buf_len) const char* str, _Inout_ int buf_len );
         void validate_key( _In_reads_(key_len) const char *key, _Inout_ int key_len);
 
     public:

--- a/source/shared/core_conn.cpp
+++ b/source/shared/core_conn.cpp
@@ -100,7 +100,7 @@ sqlsrv_conn* core_sqlsrv_connect( _In_ sqlsrv_context& henv_cp, _In_ sqlsrv_cont
                                   _In_ void* driver, _In_z_ const char* driver_func )
 
 {
-    SQLRETURN r;
+    SQLRETURN r = SQL_SUCCESS;
     std::string conn_str;
     conn_str.reserve( DEFAULT_CONN_STR_LEN );
     sqlsrv_malloc_auto_ptr<sqlsrv_conn> conn;

--- a/source/shared/core_conn.cpp
+++ b/source/shared/core_conn.cpp
@@ -787,9 +787,11 @@ void build_connection_string_and_set_conn_attr( _Inout_ sqlsrv_conn* conn, _Inou
         }
 
         zend_string *key = NULL;
-        zend_ulong index = -1;
+        zend_ulong index = 0;
         zval* data = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
         ZEND_HASH_FOREACH_KEY_VAL( options, index, key, data ) {
             int type = HASH_KEY_NON_EXISTENT;
             type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
@@ -805,6 +807,7 @@ void build_connection_string_and_set_conn_attr( _Inout_ sqlsrv_conn* conn, _Inou
 
             conn_opt->func( conn_opt, data, conn, connection_string );
         } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
         // MARS on if not explicitly turned off
         if( !mars_mentioned ) {

--- a/source/shared/core_conn.cpp
+++ b/source/shared/core_conn.cpp
@@ -189,7 +189,6 @@ sqlsrv_conn* core_sqlsrv_connect( _In_ sqlsrv_context& henv_cp, _In_ sqlsrv_cont
         ODBC_DRIVER drivers[] = { ODBC_DRIVER::VER_17, ODBC_DRIVER::VER_18, ODBC_DRIVER::VER_13 };
         ODBC_DRIVER last_version = (conn->ce_option.enabled) ? ODBC_DRIVER::VER_18 : ODBC_DRIVER::VER_13;
 
-        ODBC_DRIVER version = ODBC_DRIVER::VER_UNKNOWN;
         for (auto &d : drivers) {
             std::string driver_name = get_ODBC_driver_name(d);
 #ifndef _WIN32
@@ -342,6 +341,7 @@ SQLRETURN core_odbc_connect( _Inout_ sqlsrv_conn* conn, _Inout_ std::string& con
         r = SQLDriverConnectW( conn->handle(), NULL, wconn_string, static_cast<SQLSMALLINT>( wconn_len ), NULL, 0, &output_conn_size, SQL_DRIVER_NOPROMPT );
     }
 #else
+    (void)is_pooled;  // only used on non-Windows platforms
     r = SQLDriverConnectW( conn->handle(), NULL, wconn_string, static_cast<SQLSMALLINT>( wconn_len ), NULL, 0, &output_conn_size, SQL_DRIVER_NOPROMPT );
 #endif // !_WIN32
 
@@ -504,7 +504,7 @@ void core_sqlsrv_prepare( _Inout_ sqlsrv_stmt* stmt, _In_reads_bytes_(sql_len) c
 
             for( int i = 0; i < num_params; i++ ) {
                 param_meta_data param;
-                core::SQLDescribeParam(stmt, i + 1, &(param.sql_type), &(param.column_size), &(param.decimal_digits), &(param.nullable));
+                core::SQLDescribeParam(stmt, static_cast<SQLUSMALLINT>(i + 1), &(param.sql_type), &(param.column_size), &(param.decimal_digits), &(param.nullable));
 
                 stmt->params_container.params_meta_ae.push_back(param);
             }
@@ -647,7 +647,7 @@ bool core_is_conn_opt_value_escaped( _Inout_ const char* value, _Inout_ size_t v
 
 namespace {
 
-connection_option const* get_connection_option( sqlsrv_conn* conn, _In_ SQLULEN key,
+connection_option const* get_connection_option( sqlsrv_conn* /*conn*/, _In_ SQLULEN key,
                                                      _In_ const connection_option conn_opts[] )
 {
     for( int opt_idx = 0; conn_opts[opt_idx].conn_option_key != SQLSRV_CONN_OPTION_INVALID; ++opt_idx ) {
@@ -669,7 +669,7 @@ connection_option const* get_connection_option( sqlsrv_conn* conn, _In_ SQLULEN 
 
 void build_connection_string_and_set_conn_attr( _Inout_ sqlsrv_conn* conn, _Inout_z_ const char* server, _Inout_opt_z_  const char* uid, _Inout_opt_z_ const char* pwd,
                                                 _Inout_opt_ HashTable* options, _In_ const connection_option valid_conn_opts[],
-                                                void* driver, _Inout_ std::string& connection_string )
+                                                void* /*driver*/, _Inout_ std::string& connection_string )
 {
     bool mars_mentioned = false;
     connection_option const* conn_opt;
@@ -912,7 +912,7 @@ void load_azure_key_vault(_Inout_ sqlsrv_conn* conn)
     configure_azure_key_vault(conn, AKV_CONFIG_AUTHSECRET, akv_secret, key_size);
 }
 
-void configure_azure_key_vault(sqlsrv_conn* conn, BYTE config_attr, const DWORD config_value, size_t key_size)
+void configure_azure_key_vault(sqlsrv_conn* conn, BYTE config_attr, const DWORD config_value, size_t /*key_size*/)
 {
     BYTE akv_data[sizeof(CEKEYSTOREDATA) + sizeof(DWORD) + 1];
     CEKEYSTOREDATA *pData = reinterpret_cast<CEKEYSTOREDATA*>(akv_data);
@@ -954,7 +954,7 @@ void configure_azure_key_vault(sqlsrv_conn* conn, BYTE config_attr, const char* 
     pData->name = (wchar_t *)wakv_name.get();
 
     pData->data[0] = config_attr;
-    pData->dataSize = 1 + key_size;
+    pData->dataSize = static_cast<unsigned int>(1 + key_size);
 
     memcpy_s(pData->data + 1, key_size * sizeof(char), config_value, key_size);
 
@@ -1034,7 +1034,7 @@ void conn_null_func::func( connection_option const* /*option*/, zval* /*value*/,
 {
 }
 
-void driver_set_func::func(_In_ connection_option const* option, _In_ zval* value, _Inout_ sqlsrv_conn* conn, _Inout_ std::string& conn_str)
+void driver_set_func::func(_In_ connection_option const* /*option*/, _In_ zval* value, _Inout_ sqlsrv_conn* conn, _Inout_ std::string& conn_str)
 {
     const char* val_str = Z_STRVAL_P(value);
     size_t val_len = Z_STRLEN_P(value);
@@ -1086,7 +1086,7 @@ void column_encryption_set_func::func( _In_ connection_option const* option, _In
     conn_str += ";";
 }
 
-void ce_akv_str_set_func::func(_In_ connection_option const* option, _In_ zval* value, _Inout_ sqlsrv_conn* conn, _Inout_ std::string& conn_str)
+void ce_akv_str_set_func::func(_In_ connection_option const* option, _In_ zval* value, _Inout_ sqlsrv_conn* conn, _Inout_ std::string& /*conn_str*/)
 {
     SQLSRV_ASSERT(Z_TYPE_P(value) == IS_STRING, "Azure Key Vault keywords accept only strings.");
 
@@ -1152,14 +1152,14 @@ size_t core_str_zval_is_true(_Inout_ zval* value_z)
     if (found != std::string::npos)
         val_str.erase(found + 1);
 
-    transform(val_str.begin(), val_str.end(), val_str.begin(), ::tolower);
+    transform(val_str.begin(), val_str.end(), val_str.begin(), [](unsigned char c) { return static_cast<char>(::tolower(c)); });
     if (!val_str.compare("true") || !val_str.compare("1") || !val_str.compare("yes")) {
         return 1; // true
     }
     return 0; // false
 }
 
-void access_token_set_func::func( _In_ connection_option const* option, _In_ zval* value, _Inout_ sqlsrv_conn* conn, _Inout_ std::string& conn_str )
+void access_token_set_func::func( _In_ connection_option const* /*option*/, _In_ zval* value, _Inout_ sqlsrv_conn* conn, _Inout_ std::string& /*conn_str*/ )
 {
     SQLSRV_ASSERT(Z_TYPE_P(value) == IS_STRING, "An access token must be a byte string.");
 
@@ -1197,7 +1197,7 @@ void access_token_set_func::func( _In_ connection_option const* option, _In_ zva
     ACCESSTOKEN *pAccToken = accToken.get();
     SQLSRV_ASSERT(pAccToken != NULL, "Something went wrong when trying to allocate memory for the access token.");
 
-    pAccToken->dataSize = dataSize;
+    pAccToken->dataSize = static_cast<unsigned int>(dataSize);
 
     // Expand access token with padding bytes
     for (size_t i = 0, j = 0; i < dataSize; i += 2, j++) {

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -169,7 +169,7 @@ SQLRETURN number_to_string( _In_ Number* number_data, _Out_writes_bytes_to_opt_(
     std::locale loc;
     os.imbue(loc);
     std::use_facet< std::num_put< Char > >( loc ).put( std::basic_ostream<Char>::_Iter( os.rdbuf()), os, ' ', *number_data );
-    std::basic_string<Char>& str_num = os.str();
+    std::basic_string<Char> str_num = os.str();
 
     if ( os.fail() ) {
         last_error = new ( sqlsrv_malloc(sizeof( sqlsrv_error ))) sqlsrv_error(( SQLCHAR* ) "IMSSP", (SQLCHAR*) "Failed to convert number to string", -1 );
@@ -683,7 +683,7 @@ sqlsrv_buffered_result_set::~sqlsrv_buffered_result_set( void )
 SQLRETURN sqlsrv_buffered_result_set::fetch( _Inout_ SQLSMALLINT orientation, _Inout_opt_ SQLLEN offset )
 {
     last_error = NULL;
-    last_field_index = -1;
+    last_field_index = static_cast<SQLUSMALLINT>(-1);
     read_so_far = 0;
 
     switch( orientation ) {
@@ -735,7 +735,7 @@ SQLRETURN sqlsrv_buffered_result_set::fetch( _Inout_ SQLSMALLINT orientation, _I
 
 SQLRETURN sqlsrv_buffered_result_set::get_data( _In_ SQLUSMALLINT field_index, _In_ SQLSMALLINT target_type,
                                                 _Out_writes_bytes_opt_(buffer_length) SQLPOINTER buffer, _In_ SQLLEN buffer_length, _Inout_ SQLLEN* out_buffer_length,
-                                                bool handle_warning )
+                                                bool /*handle_warning*/ )
 {
     last_error = NULL;
     field_index--;      // convert from 1 based to 0 based
@@ -819,7 +819,7 @@ SQLRETURN sqlsrv_buffered_result_set::get_data( _In_ SQLUSMALLINT field_index, _
 
 SQLRETURN sqlsrv_buffered_result_set::get_diag_field( _In_ SQLSMALLINT record_number, _In_ SQLSMALLINT diag_identifier,
                                                       _Inout_updates_(buffer_length) SQLPOINTER diag_info_buffer, _In_ SQLSMALLINT buffer_length,
-                                                      _Inout_ SQLSMALLINT* out_buffer_length )
+                                                      _Inout_ SQLSMALLINT* /*out_buffer_length*/ )
 {
     SQLSRV_ASSERT( record_number == 1, "Only record number 1 can be fetched by sqlsrv_buffered_result_set::get_diag_field" );
     SQLSRV_ASSERT( diag_identifier == SQL_DIAG_SQLSTATE,

--- a/source/shared/core_results.cpp
+++ b/source/shared/core_results.cpp
@@ -377,7 +377,7 @@ sqlsrv_buffered_result_set::sqlsrv_buffered_result_set( _Inout_ sqlsrv_stmt* stm
     cache(NULL),
     col_count(0),
     current(0),
-    last_field_index(-1),
+    last_field_index(static_cast<SQLUSMALLINT>(-1)),
     read_so_far(0),
     temp_length(0)
 {

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -2178,16 +2178,19 @@ inline bool is_truncated_warning( _In_ SQLCHAR* state )
 #define CHECK_ZEND_ERROR( zr, ctx, error, ... )  \
     CHECK_ERROR_UNIQUE( __COUNTER__, ( zr == FAILURE ), ctx, error, ## __VA_ARGS__ )  \
 
-#define CHECK_SQL_ERROR_OR_WARNING( result, context, ... ) \
+#define CHECK_SQL_ERROR_OR_WARNING_EX( unique, result, context, ... ) \
     SQLSRV_ASSERT( result != SQL_INVALID_HANDLE, "Invalid handle returned." );  \
-    bool ignored = true;                                   \
+    bool ignored##unique = true;                                   \
     if( result == SQL_ERROR ) {                            \
-        ignored = call_error_handler( context, SQLSRV_ERROR_ODBC, 0, ##__VA_ARGS__ ); \
+        ignored##unique = call_error_handler( context, SQLSRV_ERROR_ODBC, 0, ##__VA_ARGS__ ); \
     }                                                      \
     else if( result == SQL_SUCCESS_WITH_INFO ) {           \
-        ignored = call_error_handler( context, SQLSRV_ERROR_ODBC, 1, ##__VA_ARGS__ ); \
+        ignored##unique = call_error_handler( context, SQLSRV_ERROR_ODBC, 1, ##__VA_ARGS__ ); \
     }                                                      \
-    if( !ignored )
+    if( !ignored##unique )
+
+#define CHECK_SQL_ERROR_OR_WARNING( result, context, ... ) \
+    CHECK_SQL_ERROR_OR_WARNING_EX( __COUNTER__, result, context, ##__VA_ARGS__ )
 
 // throw an exception after it has been hooked into the custom error handler
 #define THROW_CORE_ERROR( ctx, custom, ... ) \

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -31,11 +31,23 @@
 #define _WCHART_DEFINED
 #endif
 
+// Suppress warnings from PHP headers
+// C4146: unary minus operator applied to unsigned type (PHP 8.5+ php_random_uint128.h)
+// C4244: conversion with possible loss of data (various PHP headers)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4146 4244)
+#endif
+
 #include "php.h"
 #include "php_globals.h"
 #include "php_ini.h"
 #include "ext/standard/php_standard.h"
 #include "ext/standard/info.h"
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #ifndef _WIN32 // !_WIN32
 #include "FormattedPrint.h"

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -32,11 +32,18 @@
 #endif
 
 // Suppress warnings from PHP headers
+// These are third-party headers we cannot modify, so we suppress warnings here
+// C4100: unreferenced formal parameter
+// C4127: conditional expression is constant
 // C4146: unary minus operator applied to unsigned type (PHP 8.5+ php_random_uint128.h)
-// C4244: conversion with possible loss of data (various PHP headers)
+// C4244: conversion with possible loss of data
+// C4267: conversion from 'size_t' to smaller type
+// C4456: declaration hides previous local declaration
+// C4457: declaration hides function parameter
+// C4706: assignment within conditional expression
 #if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable: 4146 4244)
+#pragma warning(disable: 4100 4127 4146 4244 4267 4456 4457 4706)
 #endif
 
 #include "php.h"

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -1960,7 +1960,7 @@ struct sqlsrv_buffered_result_set : public sqlsrv_result_set {
 
 // Simple macro to alleviate unused variable warnings.  These are optimized out by the compiler.
 // We use this since the unused variables are buried in the PHP_FUNCTION macro.
-#define SQLSRV_UNUSED( var )   var;
+#define SQLSRV_UNUSED( var )   (void)(var);
 
 // do a heap check in debug mode, but only print errors, not all of the allocations
 #define MEMCHECK_SILENT 1

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -2189,8 +2189,13 @@ inline bool is_truncated_warning( _In_ SQLCHAR* state )
     }                                                      \
     if( !ignored##unique )
 
+// Three-level indirection needed: with /Zc:preprocessor, arguments adjacent to ## are NOT expanded.
+// The middle layer forces __COUNTER__ expansion before it reaches ## in CHECK_SQL_ERROR_OR_WARNING_EX.
+#define CHECK_SQL_ERROR_OR_WARNING_UNIQUE( unique, result, context, ... ) \
+    CHECK_SQL_ERROR_OR_WARNING_EX( unique, result, context, ##__VA_ARGS__ )
+
 #define CHECK_SQL_ERROR_OR_WARNING( result, context, ... ) \
-    CHECK_SQL_ERROR_OR_WARNING_EX( __COUNTER__, result, context, ##__VA_ARGS__ )
+    CHECK_SQL_ERROR_OR_WARNING_UNIQUE( __COUNTER__, result, context, ##__VA_ARGS__ )
 
 // throw an exception after it has been hooked into the custom error handler
 #define THROW_CORE_ERROR( ctx, custom, ... ) \

--- a/source/shared/core_sqlsrv.h
+++ b/source/shared/core_sqlsrv.h
@@ -1528,7 +1528,7 @@ struct sqlsrv_param_tvp : public sqlsrv_param
     virtual void process_param(_Inout_ sqlsrv_stmt* stmt, _Inout_ zval* param_z);
 
     // The following methods are used to supply data to the server post execution
-    virtual void init_data_from_zval(_Inout_ sqlsrv_stmt* stmt) {}
+    virtual void init_data_from_zval(_Inout_ sqlsrv_stmt* /*stmt*/) {}
     virtual bool send_data_packet(_Inout_ sqlsrv_stmt* stmt);
 
     // Change the column encoding based on the sql data type
@@ -1831,7 +1831,7 @@ struct sqlsrv_odbc_result_set : public sqlsrv_result_set {
     explicit sqlsrv_odbc_result_set( _In_ sqlsrv_stmt* );
 	virtual ~sqlsrv_odbc_result_set( void );
 
-    virtual bool cached( int field_index ) { return false; }
+    virtual bool cached( int /*field_index*/ ) { return false; }
     virtual SQLRETURN fetch( _In_ SQLSMALLINT fetch_orientation, _In_ SQLLEN fetch_offset );
     virtual SQLRETURN get_data( _In_ SQLUSMALLINT field_index, _In_ SQLSMALLINT target_type,
                                 _Out_writes_opt_(buffer_length) void* buffer, _In_ SQLLEN buffer_length, _Inout_ SQLLEN* out_buffer_length,
@@ -1869,7 +1869,7 @@ struct sqlsrv_buffered_result_set : public sqlsrv_result_set {
     explicit sqlsrv_buffered_result_set( _Inout_ sqlsrv_stmt* odbc );
     virtual ~sqlsrv_buffered_result_set( void );
 
-    virtual bool cached( int field_index ) { return true; }
+    virtual bool cached( int /*field_index*/ ) { return true; }
     virtual SQLRETURN fetch( _Inout_ SQLSMALLINT fetch_orientation, _Inout_opt_ SQLLEN fetch_offset );
     virtual SQLRETURN get_data( _In_ SQLUSMALLINT field_index, _In_ SQLSMALLINT target_type,
                                 _Out_writes_bytes_opt_(buffer_length) void* buffer, _In_ SQLLEN buffer_length, _Inout_ SQLLEN* out_buffer_length,
@@ -2070,7 +2070,7 @@ enum error_handling_flags {
 // 2/code) driver specific error code
 // 3/message) driver specific error message
 // The fetch type determines if the indices are numeric, associative, or both.
-bool core_sqlsrv_get_odbc_error( _Inout_ sqlsrv_context& ctx, _In_ int record_number, _Inout_ sqlsrv_error_auto_ptr& error,
+bool core_sqlsrv_get_odbc_error( _Inout_ sqlsrv_context& ctx, _In_ SQLSMALLINT record_number, _Inout_ sqlsrv_error_auto_ptr& error,
                                  _In_ logging_severity severity, _In_opt_ bool check_warning = false );
 
 // format and return a driver specfic error
@@ -2737,7 +2737,7 @@ namespace core {
         }
     }
 
-    inline void sqlsrv_zend_hash_init(sqlsrv_context& ctx, _Inout_ HashTable* ht, _Inout_ uint32_t initial_size,
+    inline void sqlsrv_zend_hash_init(sqlsrv_context& /*ctx*/, _Inout_ HashTable* ht, _Inout_ uint32_t initial_size,
         _In_ dtor_func_t dtor_fn, _In_ zend_bool persistent )
     {
         ::zend_hash_init(ht, initial_size, NULL, dtor_fn, persistent);

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -293,10 +293,12 @@ sqlsrv_stmt* core_sqlsrv_create_stmt( _Inout_ sqlsrv_conn* conn, _In_ driver_stm
 
         // process the options array given to core_sqlsrv_prepare.
         if( options_ht && zend_hash_num_elements( options_ht ) > 0 && valid_stmt_opts ) {
-            zend_ulong index = -1;
+            zend_ulong index = 0;
             zend_string *key = NULL;
             zval* value_z = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
             ZEND_HASH_FOREACH_KEY_VAL( options_ht, index, key, value_z ) {
 
                 int type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
@@ -313,6 +315,7 @@ sqlsrv_stmt* core_sqlsrv_create_stmt( _Inout_ sqlsrv_conn* conn, _In_ driver_stm
                 // perform the actions the statement option needs done.
                 (*stmt_opt->func)( stmt, stmt_opt, value_z );
             } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
         }
 
         // The query timeout setting is inherited from the corresponding connection attribute, but
@@ -2119,7 +2122,7 @@ void sqlsrv_param::copy_param_meta_ae(_Inout_ zval* param_z, _In_ param_meta_dat
     }
 }
 
-bool sqlsrv_param::prepare_param(_In_ zval* param_ref, _Inout_ zval* param_z)
+bool sqlsrv_param::prepare_param(_In_ zval* /*param_ref*/, _Inout_ zval* param_z)
 {
     // For input parameters, check if the original parameter was null
     was_null = (Z_TYPE_P(param_z) == IS_NULL);
@@ -2164,7 +2167,7 @@ void sqlsrv_param::process_param(_Inout_ sqlsrv_stmt* stmt, _Inout_ zval* param_
     }
 }
 
-void sqlsrv_param::process_null_param(_Inout_ zval* param_z)
+void sqlsrv_param::process_null_param(_Inout_ zval* /*param_z*/)
 {
     // Derive the param SQL type only if it is unknown
     if (sql_data_type == SQL_UNKNOWN_TYPE) {
@@ -2248,7 +2251,7 @@ void sqlsrv_param::process_double_param(_Inout_ zval* param_z)
     strlen_or_indptr = buffer_length;
 }
 
-bool sqlsrv_param::derive_string_types_sizes(_In_ zval* param_z)
+bool sqlsrv_param::derive_string_types_sizes(_In_ zval* /*param_z*/)
 {
     SQLSRV_ASSERT(encoding == SQLSRV_ENCODING_CHAR || encoding == SQLSRV_ENCODING_UTF8 || encoding == SQLSRV_ENCODING_BINARY, "Invalid encoding in sqlsrv_param::derive_string_types_sizes");
 
@@ -2289,7 +2292,7 @@ bool sqlsrv_param::derive_string_types_sizes(_In_ zval* param_z)
     return is_numeric;
 }
 
-bool sqlsrv_param::convert_input_str_to_utf16(_Inout_ sqlsrv_stmt* stmt, _In_ zval* param_z)
+bool sqlsrv_param::convert_input_str_to_utf16(_Inout_ sqlsrv_stmt* /*stmt*/, _In_ zval* param_z)
 {
     // This converts the string in param_z and stores the wide string in the member placeholder_z
     char* str = Z_STRVAL_P(param_z);
@@ -2394,7 +2397,7 @@ void sqlsrv_param::process_resource_param(_Inout_ zval* param_z)
     strlen_or_indptr = SQL_DATA_AT_EXEC;
 }
 
-bool sqlsrv_param::convert_datetime_to_string(_Inout_ sqlsrv_stmt* stmt, _In_ zval* param_z)
+bool sqlsrv_param::convert_datetime_to_string(_Inout_ sqlsrv_stmt* /*stmt*/, _In_ zval* param_z)
 {
     // This changes the member placeholder_z to hold the converted string of the datetime object
     zval function_z;
@@ -2535,7 +2538,10 @@ bool sqlsrv_param::send_data_packet(_Inout_ sqlsrv_stmt* stmt)
         return false;
     } else {
         // Read the data from the stream, send it via SQLPutData and track how much is already sent.
+#pragma warning(push)
+#pragma warning(disable: 4458) // declaration of 'buffer' hides class member - intentional local buffer
         char buffer[PHP_STREAM_BUFFER_SIZE + 1] = { '\0' };
+#pragma warning(pop)
         std::size_t buffer_size = sizeof(buffer) - 3;   // -3 to preserve enough space for a cut off UTF-8 character
         std::size_t read = php_stream_read(param_stream, buffer, buffer_size);
 
@@ -2676,6 +2682,8 @@ bool sqlsrv_param_inout::prepare_param(_In_ zval* param_ref, _Inout_ zval* param
 
 // Derives the ODBC C type constant that matches the PHP type and/or the encoding given
 // If SQL type or column size is unknown, derives the appropriate values as well using the provided param zval and encoding
+#pragma warning(push)
+#pragma warning(disable: 4458) // declaration of 'stmt' hides class member - intentional, assigned to this->stmt
 void sqlsrv_param_inout::process_param(_Inout_ sqlsrv_stmt* stmt, zval* param_z)
 {
     // Get param php type NOW because the original parameter might have been converted beforehand
@@ -2699,7 +2707,10 @@ void sqlsrv_param_inout::process_param(_Inout_ sqlsrv_stmt* stmt, zval* param_z)
     // Save the pointer to the statement object
     this->stmt = stmt;
 }
+#pragma warning(pop)
 
+#pragma warning(push)
+#pragma warning(disable: 4458) // declaration of 'stmt' hides class member
 void sqlsrv_param_inout::process_string_param(_Inout_ sqlsrv_stmt* stmt, _Inout_ zval* param_z)
 {
     bool is_numeric_type = derive_string_types_sizes(param_z);
@@ -2770,6 +2781,7 @@ void sqlsrv_param_inout::process_string_param(_Inout_ sqlsrv_stmt* stmt, _Inout_
         }
     }
 }
+#pragma warning(pop)
 
 // Called when the output parameter is ready to be finalized, using the value stored in param_ptr_z
 void sqlsrv_param_inout::finalize_output_value()
@@ -3143,7 +3155,7 @@ int sqlsrv_param_tvp::parse_tv_param_arrays(_Inout_ sqlsrv_stmt* stmt, _Inout_ z
     zend_hash_internal_pointer_reset_ex(inputs_ht, &pos);
     if (zend_hash_has_more_elements_ex(inputs_ht, &pos) == SUCCESS) {
 
-        zend_ulong num_index = -1;
+        zend_ulong num_index = 0;
         size_t key_len = 0;
 
         int key_type = zend_hash_get_current_key(inputs_ht, &tvp_name, &num_index);
@@ -3196,13 +3208,15 @@ int sqlsrv_param_tvp::parse_tv_param_arrays(_Inout_ sqlsrv_stmt* stmt, _Inout_ z
 
     // (1) Is the array empty?
     // (2) Check individual rows and see if their sizes are consistent?
-    zend_ulong id = -1;
+    zend_ulong id = 0;
     zend_string *key = NULL;
     zval* row_z = NULL;
     int num_columns = 0;
     int type = HASH_KEY_NON_EXISTENT;
 
     // Loop through the rows to check the number of columns
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
     ZEND_HASH_FOREACH_KEY_VAL(rows_ht, id, key, row_z) {
         type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
         CHECK_CUSTOM_ERROR(type == HASH_KEY_IS_STRING, stmt, SQLSRV_ERROR_TVP_STRING_KEYS, param_pos + 1, NULL) {
@@ -3224,6 +3238,7 @@ int sqlsrv_param_tvp::parse_tv_param_arrays(_Inout_ sqlsrv_stmt* stmt, _Inout_ z
             throw core::CoreException();
         }
     } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
     // Return the number of columns
     return num_columns;
@@ -3371,13 +3386,15 @@ void sqlsrv_param_tvp::bind_param(_Inout_ sqlsrv_stmt* stmt)
     }
 
     HashTable* cols_ht = Z_ARRVAL_P(row_z);
-    zend_ulong id = -1;
+    zend_ulong id = 0;
     zend_string *key = NULL;
     zval* data_z = NULL;
     int num_columns = 0;
 
     // In case there are null values in the first row, have to loop
     // through the entire first row of column values using the Zend macros.
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
     ZEND_HASH_FOREACH_KEY_VAL(cols_ht, id, key, data_z) {
         int type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
         CHECK_CUSTOM_ERROR(type == HASH_KEY_IS_STRING, stmt, SQLSRV_ERROR_TVP_STRING_KEYS, param_pos + 1, NULL) {
@@ -3397,6 +3414,7 @@ void sqlsrv_param_tvp::bind_param(_Inout_ sqlsrv_stmt* stmt)
         column_param->param_ptr_z = data_z;
         num_columns++;
     } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
     // Process the columns and bind each of them using the saved data
     for (int i = 0; i < num_columns; i++) {
@@ -3413,14 +3431,13 @@ void sqlsrv_param_tvp::bind_param(_Inout_ sqlsrv_stmt* stmt)
 // For each of the constituent columns of the table-valued parameter, check its PHP type
 // For pure scalar types, map the cell value (based on current_row and ordinal) to the
 // member placeholder_z
-void sqlsrv_param_tvp::populate_cell_placeholder(_Inout_ sqlsrv_stmt* stmt, _In_ int ordinal)
+void sqlsrv_param_tvp::populate_cell_placeholder(_Inout_ sqlsrv_stmt* /*stmt*/, _In_ int ordinal)
 {
     if (sql_data_type == SQL_SS_TABLE || ordinal >= num_rows) {
         return;
     }
 
     zval* row_z = NULL;
-    HashTable* values_ht = NULL;
     zval* value_z = NULL;
     int type = IS_NULL;
 

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -948,7 +948,7 @@ bool core_sqlsrv_has_any_result( _Inout_ sqlsrv_stmt* stmt )
     else {
         // Use SQLRowCount to determine if there is a rows status waiting
         rows_affected = core::SQLRowCount( stmt );
-        stmt->row_count = rows_affected;
+        stmt->row_count = static_cast<long>(rows_affected);
     }
 
     return (num_cols != 0) || (rows_affected > 0);
@@ -1606,7 +1606,7 @@ void format_decimal_numbers(_In_ SQLSMALLINT decimals_places, _In_ SQLSMALLINT f
 
     char buffer[50] = "  ";             // A buffer with TWO blank spaces, as leeway
     int offset = 1 + is_negative;       // for cases like 9.* to 10.* and the minus sign if needed
-    int src_length = strnlen_s(src);
+    int src_length = static_cast<int>(strnlen_s(src));
 
     if (add_leading_zero) {
         buffer[offset++] = '0';         // leading zero added
@@ -1618,10 +1618,10 @@ void format_decimal_numbers(_In_ SQLSMALLINT decimals_places, _In_ SQLSMALLINT f
 
     // If no need to adjust decimal places, skip formatting
     if (decimals_places != NO_CHANGE_DECIMAL_PLACES) {
-        int num_decimals = src_length - (pt - src) - 1;
+        int num_decimals = src_length - static_cast<int>(pt - src) - 1;
 
         if (num_decimals > scale) {
-            last_pos = round_up_decimal_numbers(buffer, (pt - src) + offset, scale, offset, last_pos);
+            last_pos = round_up_decimal_numbers(buffer, static_cast<int>(pt - src) + offset, scale, offset, last_pos);
         }
     }
 
@@ -1647,7 +1647,7 @@ void get_field_as_string(_Inout_ sqlsrv_stmt *stmt, _In_ SQLUSMALLINT field_inde
 {
     SQLRETURN r;
     SQLSMALLINT c_type;
-    SQLSMALLINT sql_field_type = 0;
+    SQLLEN sql_field_type = 0;
     SQLSMALLINT extra = 0;
     SQLLEN field_len_temp = 0;
     SQLLEN sql_display_size = 0;
@@ -1896,7 +1896,7 @@ bool is_valid_sqlsrv_phptype( _In_ sqlsrv_phptype type )
 void adjustDecimalPrecision(_Inout_ zval* param_z, _In_ SQLSMALLINT decimal_digits)
 {
     char* value = Z_STRVAL_P(param_z);
-    int value_len = Z_STRLEN_P(param_z);
+    int value_len = static_cast<int>(Z_STRLEN_P(param_z));
 
     // If the length is greater than maxDecimalStrLen, do not convert the string
     // 6 is derived from: 1 for the decimal point; 1 for sign of the number; 1 for 'e' or 'E' (scientific notation);
@@ -1943,14 +1943,14 @@ void adjustDecimalPrecision(_Inout_ zval* param_z, _In_ SQLSMALLINT decimal_digi
 			return;		// decimal point not found
 		}
 
-        int src_length = strnlen_s(src);
-        int num_decimals = src_length - (pt - src) - 1;
+        int src_length = static_cast<int>(strnlen_s(src));
+        int num_decimals = src_length - static_cast<int>(pt - src) - 1;
 		if (num_decimals <= decimal_digits) {
 			return;     // no need to adjust number of decimals
 		}
 
         memcpy_s(buffer + offset, src_length, src, src_length);
-        round_up_decimal_numbers(buffer, (pt - src) + offset, decimal_digits, offset, src_length + offset);
+        round_up_decimal_numbers(buffer, static_cast<int>(pt - src) + offset, decimal_digits, offset, src_length + offset);
     }
     else {
         int power = atoi(exp+1);
@@ -1961,24 +1961,24 @@ void adjustDecimalPrecision(_Inout_ zval* param_z, _In_ SQLSMALLINT decimal_digi
         int num_decimals = 0;
         if (power == 0) {
             // Simply chop off the exp part
-            int length = (exp - src);
+            int length = static_cast<int>(exp - src);
             memcpy_s(buffer + offset, length, src, length);
 
             if (pt != NULL) {
                 // Adjust decimal places only if decimal point is found and number of decimals more than decimal_digits
-                num_decimals = exp - pt - 1;
+                num_decimals = static_cast<int>(exp - pt) - 1;
                 if (num_decimals > decimal_digits) {
-                    round_up_decimal_numbers(buffer, (pt - src) + offset, decimal_digits, offset, length + offset);
+                    round_up_decimal_numbers(buffer, static_cast<int>(pt - src) + offset, decimal_digits, offset, length + offset);
                 }
             }
         } else {
             int oldpos = 0;
             if (pt == NULL) {
-                oldpos = exp - src;     // Decimal point not found, use the exp sign
+                oldpos = static_cast<int>(exp - src);     // Decimal point not found, use the exp sign
             }
             else {
-                oldpos = pt - src;
-                num_decimals = exp - pt - 1;
+                oldpos = static_cast<int>(pt - src);
+                num_decimals = static_cast<int>(exp - pt) - 1;
                 if (power > 0 && num_decimals <= power) {
                     return;             // The result will be a whole number, do nothing and return
                 }
@@ -3563,7 +3563,7 @@ bool sqlsrv_param_tvp::send_data_packet(_Inout_ sqlsrv_stmt* stmt)
         // This is the table-valued parameter
         if (current_row < num_rows) {
             // Loop through the table parameter columns and populate each cell's placeholder whenever applicable
-            for (size_t i = 0; i < tvp_columns.size(); i++) {
+            for (SQLUSMALLINT i = 0; i < static_cast<SQLUSMALLINT>(tvp_columns.size()); i++) {
                 tvp_columns[i]->populate_cell_placeholder(stmt, current_row);
             }
 

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -1835,7 +1835,7 @@ void get_field_as_string(_Inout_ sqlsrv_stmt *stmt, _In_ SQLUSMALLINT field_inde
 // return the option from the stmt_opts array that matches the key.  If no option found,
 // NULL is returned.
 
-stmt_option const* get_stmt_option( sqlsrv_conn const* conn, _In_ zend_ulong key, _In_ const stmt_option stmt_opts[] )
+stmt_option const* get_stmt_option( sqlsrv_conn const* /*conn*/, _In_ zend_ulong key, _In_ const stmt_option stmt_opts[] )
 {
     for( int i = 0; stmt_opts[i].key != SQLSRV_STMT_OPTION_INVALID; ++i ) {
 

--- a/source/shared/core_stmt.cpp
+++ b/source/shared/core_stmt.cpp
@@ -865,7 +865,7 @@ void core_sqlsrv_get_field( _Inout_ sqlsrv_stmt* stmt, _In_ SQLUSMALLINT field_i
             invalid.typeinfo.type = SQLSRV_PHPTYPE_INVALID;
             for( int i = stmt->last_field_index + 1; i < field_index; ++i ) {
                SQLSRV_ASSERT( reinterpret_cast<field_cache*>( zend_hash_index_find_ptr( Z_ARRVAL( stmt->field_cache ), i )) == NULL, "Field already cached." );
-               core_sqlsrv_get_field( stmt, i, invalid, prefer_string, field_value, field_len, cache_field, sqlsrv_php_type_out );
+               core_sqlsrv_get_field( stmt, static_cast<SQLUSMALLINT>(i), invalid, prefer_string, field_value, field_len, cache_field, sqlsrv_php_type_out );
                // delete the value returned since we only want it cached, not the actual value
                if( field_value ) {
                    efree( field_value );
@@ -1691,7 +1691,7 @@ void get_field_as_string(_Inout_ sqlsrv_stmt *stmt, _In_ SQLUSMALLINT field_inde
             extra = sizeof(SQLCHAR);
 
             // For numbers, no need to convert
-            if (sqlsrv_php_type.typeinfo.encoding == CP_UTF8 && !is_a_numeric_type(sql_field_type)) {
+            if (sqlsrv_php_type.typeinfo.encoding == CP_UTF8 && !is_a_numeric_type(static_cast<SQLSMALLINT>(sql_field_type))) {
                 c_type = SQL_C_WCHAR;
                 extra = sizeof(SQLWCHAR);
 
@@ -2003,7 +2003,7 @@ void adjustDecimalPrecision(_Inout_ zval* param_z, _In_ SQLSMALLINT decimal_digi
                 // Whether to pad zeroes depending on the original position of the decimal point pos.
                 if (newpos <= 0) {
                     // If newpos is negative or zero, pad zeroes (size of '0.' + places to move) in the buffer
-                    short numzeroes = 2 + abs(newpos);
+                    int numzeroes = 2 + abs(newpos);
                     memset(buffer + offset, '0', numzeroes);
                     newpos = offset + 1;                    // The new decimal position should be offset + '0'
                     buffer[newpos] = DECIMAL_POINT;			// Replace that '0' with the decimal point
@@ -2057,11 +2057,11 @@ int round_up_decimal_numbers(_Inout_ char* buffer, _In_ int decimal_pos, _In_ in
 
     int pos = decimal_pos + num_decimals + 1;
     if (pos < lastpos) {
-        short n = buffer[pos] - '0';
+        int n = buffer[pos] - '0';
         if (n >= 5) {
             // Start rounding up - starting from the digit left of pos all the way to the first digit
             bool carry_over = true;
-            for (short p = pos - 1; p >= offset && carry_over; p--) {
+            for (int p = pos - 1; p >= offset && carry_over; p--) {
                 if (buffer[p] == DECIMAL_POINT) {
                     continue;
                 }
@@ -2070,7 +2070,7 @@ int round_up_decimal_numbers(_Inout_ char* buffer, _In_ int decimal_pos, _In_ in
                 if (n == 10) {
                     n = 0;
                 }
-                buffer[p] = '0' + n;
+                buffer[p] = static_cast<char>('0' + n);
             }
             if (carry_over) {
                 buffer[offset - 1] = '1';
@@ -3418,7 +3418,7 @@ void sqlsrv_param_tvp::bind_param(_Inout_ sqlsrv_stmt* stmt)
 
     // Process the columns and bind each of them using the saved data
     for (int i = 0; i < num_columns; i++) {
-        sqlsrv_param* column_param = tvp_columns[i];
+        sqlsrv_param* column_param = tvp_columns[static_cast<SQLUSMALLINT>(i)];
 
         column_param->process_param(stmt, NULL);
         column_param->bind_param(stmt);

--- a/source/shared/core_util.cpp
+++ b/source/shared/core_util.cpp
@@ -257,7 +257,7 @@ void convert_datetime_string_to_zval(_Inout_ sqlsrv_stmt* stmt, _In_opt_ char* i
 // 3/message) driver specific error message
 // The fetch type determines if the indices are numeric, associative, or both.
 
-bool core_sqlsrv_get_odbc_error( _Inout_ sqlsrv_context& ctx, _In_ int record_number, _Inout_ sqlsrv_error_auto_ptr& error, _In_ logging_severity severity, _In_opt_ bool check_warning /* = false */)
+bool core_sqlsrv_get_odbc_error( _Inout_ sqlsrv_context& ctx, _In_ SQLSMALLINT record_number, _Inout_ sqlsrv_error_auto_ptr& error, _In_ logging_severity severity, _In_opt_ bool check_warning /* = false */)
 {
     SQLHANDLE h = ctx.handle();
     SQLSMALLINT h_type = ctx.handle_type();
@@ -445,8 +445,11 @@ namespace {
 // to convert.
 unsigned int convert_string_from_default_encoding( _In_ unsigned int php_encoding, _In_reads_bytes_(mbcs_len) char const* mbcs_in_string,
                                                    _In_ unsigned int mbcs_len, _Out_writes_(utf16_len) __transfer( mbcs_in_string ) SQLWCHAR* utf16_out_string,
-                                                   _In_ unsigned int utf16_len, bool use_strict_conversion )
+                                                   _In_ unsigned int utf16_len, _In_ bool use_strict_conversion )
 {
+#ifdef _WIN32
+    (void)use_strict_conversion;  // Not used on Windows
+#endif
     unsigned int win_encoding = CP_ACP;
     switch( php_encoding ) {
         case SQLSRV_ENCODING_CHAR:
@@ -549,7 +552,7 @@ namespace data_classification {
             namelen = *ptr++;
             nameptr = ptr;
 
-            pair->name_len = namelen;
+            pair->name_len = static_cast<UCHAR>(namelen);
             convert_sensivity_field(stmt, encoding, nameptr, namelen, (char**)&name, field_len);
             pair->name = name;
 
@@ -558,7 +561,7 @@ namespace data_classification {
             idptr = ptr;
             ptr += idlen * 2;
 
-            pair->id_len = idlen;
+            pair->id_len = static_cast<UCHAR>(idlen);
             convert_sensivity_field(stmt, encoding, idptr, idlen, (char**)&id, field_len);
             pair->id = id;
 

--- a/source/sqlsrv/config.w32
+++ b/source/sqlsrv/config.w32
@@ -37,7 +37,7 @@ if( PHP_SQLSRV != "no" ) {
             ADD_FLAG( "CFLAGS_SQLSRV", "/EHsc" );
             ADD_FLAG( "CFLAGS_SQLSRV", "/GS" );
             ADD_FLAG( "CFLAGS_SQLSRV", "/Zi" );
-            ADD_FLAG( "CFLAGS_SQLSRV", "/ZH:SHA_256 /sdl /W3" );
+            ADD_FLAG( "CFLAGS_SQLSRV", "/ZH:SHA_256 /sdl /W4 /WX" );
             ADD_FLAG( "LDFLAGS_SQLSRV", "/CETCOMPAT" );
             if (VCVERS >= 1913) {
                 ADD_FLAG("LDFLAGS_SQLSRV", "/d2:-guardspecload");

--- a/source/sqlsrv/config.w32
+++ b/source/sqlsrv/config.w32
@@ -39,7 +39,6 @@ if( PHP_SQLSRV != "no" ) {
             ADD_FLAG( "CFLAGS_SQLSRV", "/Zi" );
             ADD_FLAG( "CFLAGS_SQLSRV", "/ZH:SHA_256 /sdl /W3" );
             ADD_FLAG( "LDFLAGS_SQLSRV", "/CETCOMPAT" );
-            ADD_FLAG( "CFLAGS_SQLSRV", "/wd4146" );
             if (VCVERS >= 1913) {
                 ADD_FLAG("LDFLAGS_SQLSRV", "/d2:-guardspecload");
                 ADD_FLAG("CFLAGS_SQLSRV", "/Qspectre");

--- a/source/sqlsrv/conn.cpp
+++ b/source/sqlsrv/conn.cpp
@@ -81,10 +81,12 @@ struct conn_char_set_func {
          const char* encoding = Z_STRVAL_P( value );
          size_t encoding_len = Z_STRLEN_P( value );
 
-         zend_ulong index = -1;
+         zend_ulong index = 0;
          zend_string* key = NULL;
          void* ss_encoding_temp = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
          ZEND_HASH_FOREACH_KEY_PTR( g_ss_encodings_ht, index, key, ss_encoding_temp ) {
              sqlsrv_encoding* ss_encoding = reinterpret_cast<sqlsrv_encoding*>( ss_encoding_temp );
              ss_encoding_temp = NULL;
@@ -98,6 +100,7 @@ struct conn_char_set_func {
                  return;
              }
          } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
          THROW_SS_ERROR( conn, SS_SQLSRV_ERROR_CONNECT_ILLEGAL_ENCODING, encoding, NULL );
     }
@@ -1314,6 +1317,8 @@ void sqlsrv_conn_close_stmts( _Inout_ ss_sqlsrv_conn* conn )
     // ODBC connection
 
     zval* rsrc_ptr = NULL;
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
     ZEND_HASH_FOREACH_VAL( conn->stmts, rsrc_ptr ) {
         try {
             int zr = ( rsrc_ptr ) != NULL ? SUCCESS : FAILURE;
@@ -1349,6 +1354,7 @@ void sqlsrv_conn_close_stmts( _Inout_ ss_sqlsrv_conn* conn )
         zend_list_close(Z_RES_P(rsrc_ptr));
 #endif
     } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
     zend_hash_destroy( conn->stmts );
     FREE_HASHTABLE( conn->stmts );
@@ -1459,9 +1465,11 @@ void validate_stmt_options( _Inout_ sqlsrv_context& ctx, _Inout_ zval* stmt_opti
         if( stmt_options ) {
 
             HashTable* options_ht = Z_ARRVAL_P( stmt_options );
-            zend_ulong int_key = -1;
+            zend_ulong int_key = 0;
             zend_string *key = NULL;
             zval* data = NULL;
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
             ZEND_HASH_FOREACH_KEY_VAL( options_ht, int_key, key, data ) {
                 int type = HASH_KEY_NON_EXISTENT;
                 size_t key_len = 0;
@@ -1481,6 +1489,7 @@ void validate_stmt_options( _Inout_ sqlsrv_context& ctx, _Inout_ zval* stmt_opti
                     DIE( "validate_stmt_options: key was null." );
                 }
             } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
         }
     }
     catch( core::CoreException& ) {
@@ -1500,9 +1509,11 @@ void validate_conn_options( _Inout_ sqlsrv_context& ctx, _In_ zval* user_options
         if( user_options_z ) {
 
             HashTable* options_ht = Z_ARRVAL_P( user_options_z );
-            zend_ulong int_key = -1;
+            zend_ulong int_key = 0;
             zend_string *key = NULL;
             zval* data = NULL;
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
             ZEND_HASH_FOREACH_KEY_VAL( options_ht, int_key, key, data ) {
                 int type = HASH_KEY_NON_EXISTENT;
                 type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
@@ -1535,6 +1546,7 @@ void validate_conn_options( _Inout_ sqlsrv_context& ctx, _In_ zval* user_options
                     DIE( "validate_conn_options: key was null." );
                 }
             } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
         }
     }
     catch( core::CoreException& ) {

--- a/source/sqlsrv/conn.cpp
+++ b/source/sqlsrv/conn.cpp
@@ -117,7 +117,7 @@ struct bool_conn_str_func {
         }
 
         attr = Z_STRVAL_P(value);
-        transform(attr.begin(), attr.end(), attr.begin(), ::tolower);
+        transform(attr.begin(), attr.end(), attr.begin(), [](unsigned char c) { return static_cast<char>(::tolower(c)); });
 
         char temp_str[MAX_CONN_VALSTRING_LEN];
         snprintf(temp_str,

--- a/source/sqlsrv/init.cpp
+++ b/source/sqlsrv/init.cpp
@@ -271,7 +271,7 @@ zend_module_entry g_sqlsrv_module_entry =
 
 PHP_MINIT_FUNCTION(sqlsrv)
 {
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( type );
 
     core_sqlsrv_register_severity_checker(ss_severity_check);
 
@@ -598,7 +598,7 @@ void sqlsrv_encoding_dtor( _Inout_ zval* elem ) {
 
 PHP_MSHUTDOWN_FUNCTION(sqlsrv)
 {
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( type );
 	
     UNREGISTER_INI_ENTRIES();
 
@@ -632,8 +632,8 @@ PHP_MSHUTDOWN_FUNCTION(sqlsrv)
 
 PHP_RINIT_FUNCTION(sqlsrv)
 {
-    // SQLSRV_UNUSED( module_number );
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( module_number );
+    SQLSRV_UNUSED( type );
 
 #if defined(ZTS) 
     ZEND_TSRMLS_CACHE_UPDATE();
@@ -692,8 +692,8 @@ PHP_RINIT_FUNCTION(sqlsrv)
 
 PHP_RSHUTDOWN_FUNCTION(sqlsrv)
 {
-    // SQLSRV_UNUSED( module_number );
-    // SQLSRV_UNUSED( type );
+    SQLSRV_UNUSED( module_number );
+    SQLSRV_UNUSED( type );
 
     LOG_FUNCTION( "PHP_RSHUTDOWN for php_sqlsrv" );
     reset_errors();

--- a/source/sqlsrv/php_sqlsrv.h
+++ b/source/sqlsrv/php_sqlsrv.h
@@ -22,7 +22,17 @@
 //  IN THE SOFTWARE.
 //---------------------------------------------------------------------------------------------------------------------------------
 
+// Suppress warnings from PHP headers that we cannot modify
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4244 4267 4456 4457 4706)
+#endif
+
 #include "php.h"
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 //*********************************************************************************************************************************
 // Global variables

--- a/source/sqlsrv/php_sqlsrv_int.h
+++ b/source/sqlsrv/php_sqlsrv_int.h
@@ -359,7 +359,7 @@ namespace ss {
 template <typename H>
 inline H* process_params( INTERNAL_FUNCTION_PARAMETERS, _In_ char const* param_spec, _In_ const char* calling_func, _In_ size_t param_count, ... )
 {
-    // SQLSRV_UNUSED( return_value );
+    SQLSRV_UNUSED( return_value );
 
     zval* rsrc;
     H* h = NULL;

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -870,6 +870,8 @@ PHP_FUNCTION( sqlsrv_fetch_object )
 
 				int i = 0;
 				zval* value_z = NULL;
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
 				ZEND_HASH_FOREACH_VAL( ctor_params_ht, value_z ) {
 					zr = ( value_z ) ? SUCCESS : FAILURE;
 					CHECK_ZEND_ERROR( zr, stmt, SS_SQLSRV_ERROR_ZEND_OBJECT_FAILED, class_name, NULL ) {
@@ -878,6 +880,7 @@ PHP_FUNCTION( sqlsrv_fetch_object )
 					ZVAL_COPY_VALUE(&params_m[i], value_z);
 					i++;
 				} ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
             } //if( !Z_ISUNDEF( ctor_params_z ))
 
             // call the constructor function itself.
@@ -1193,10 +1196,12 @@ void bind_params( _Inout_ ss_sqlsrv_stmt* stmt )
 
         HashTable* params_ht = Z_ARRVAL_P( params_z );
 
-        zend_ulong index = -1;
+        zend_ulong index = 0;
         zend_string *key = NULL;
         zval* param_z = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
         ZEND_HASH_FOREACH_KEY_VAL( params_ht, index, key, param_z ) {
             // make sure it's an integer index
             int type = key ? HASH_KEY_IS_STRING : HASH_KEY_IS_LONG;
@@ -1261,6 +1266,7 @@ void bind_params( _Inout_ ss_sqlsrv_stmt* stmt )
                 decimal_digits );
 
         } ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
     }
     catch( core::CoreException& ) {
         stmt->free_param_data();
@@ -2082,8 +2088,10 @@ bool is_valid_sqlsrv_sqltype( _In_ sqlsrv_sqltype sql_type )
 bool verify_and_set_encoding( _In_ const char* encoding_string, _Inout_ sqlsrv_phptype& phptype_encoding )
 {
 	void* encoding_temp = NULL;
-	zend_ulong index = -1;
+	zend_ulong index = 0;
 	zend_string* key = NULL;
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
 	ZEND_HASH_FOREACH_KEY_PTR( g_ss_encodings_ht, index, key, encoding_temp ) {
         if (encoding_temp) {
             sqlsrv_encoding* encoding = reinterpret_cast<sqlsrv_encoding*>(encoding_temp);
@@ -2097,6 +2105,7 @@ bool verify_and_set_encoding( _In_ const char* encoding_string, _Inout_ sqlsrv_p
             DIE("Fatal: Error retrieving encoding from encoding hash table.");
         }
 	} ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
     return false;
 }

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -1441,7 +1441,7 @@ void stmt_option_ss_scrollable:: operator()( _Inout_ sqlsrv_stmt* stmt, stmt_opt
     }
 
     const char* scroll_type = Z_STRVAL_P( value_z );
-    unsigned long cursor_type = -1;
+    unsigned long cursor_type = ULONG_MAX;
 
     // find which cursor type they would like and set the ODBC statement attribute as such
     if( !stricmp( scroll_type, SSCursorTypes::QUERY_OPTION_SCROLLABLE_STATIC )) {

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -120,7 +120,7 @@ namespace SSCursorTypes {
 ss_sqlsrv_stmt::ss_sqlsrv_stmt( _In_ sqlsrv_conn* c, _In_ SQLHANDLE handle, _In_ error_callback e, _In_ void* drv ) :
     sqlsrv_stmt( c, handle, e, drv ),
     prepared( false ),
-    conn_index( -1 ),
+    conn_index( static_cast<zend_ulong>(-1) ),
     params_z( NULL ),
     fetch_field_names( NULL ),
     fetch_fields_count ( 0 )
@@ -526,7 +526,10 @@ PHP_FUNCTION( sqlsrv_field_metadata )
     }
 
     // return our built collection and transfer ownership
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from RETURN_ZVAL macro
     RETURN_ZVAL(&result_meta_data, 1, 1);
+#pragma warning(pop)
 
     }
     catch( core::CoreException& ) {
@@ -914,7 +917,10 @@ PHP_FUNCTION( sqlsrv_fetch_object )
             }
 
          } //if( class_entry->constructor )
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from RETURN_ZVAL macro
 		RETURN_ZVAL( &retval_z, 1, 1 );
+#pragma warning(pop)
     }
 
     catch( core::CoreException& ) {
@@ -1101,7 +1107,10 @@ PHP_FUNCTION( sqlsrv_get_field )
                                &sqlsrv_php_type_out );
         convert_to_zval( stmt, sqlsrv_php_type_out, field_value, field_len, retval_z );
         sqlsrv_free( field_value );
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from RETURN_ZVAL macro
         RETURN_ZVAL( &retval_z, 1, 1 );
+#pragma warning(pop)
     }
 
     catch( core::CoreException& ) {
@@ -1808,7 +1817,7 @@ SQLSMALLINT get_resultset_meta_data(_Inout_ sqlsrv_stmt * stmt)
     // get the numer of columns in the result set
     SQLSMALLINT num_cols = -1;
 
-    num_cols = stmt->current_meta_data.size();
+    num_cols = static_cast<SQLSMALLINT>(stmt->current_meta_data.size());
     bool getMetaData = false;
 
     if (num_cols == 0) {
@@ -1823,7 +1832,7 @@ SQLSMALLINT get_resultset_meta_data(_Inout_ sqlsrv_stmt * stmt)
 
     try {
         if (getMetaData) {
-            for (int i = 0; i < num_cols; i++) {
+            for (SQLSMALLINT i = 0; i < num_cols; i++) {
                 sqlsrv_malloc_auto_ptr<field_meta_data> core_meta_data;
                 core_meta_data = core_sqlsrv_field_metadata(stmt, i);
                 stmt->current_meta_data.push_back(core_meta_data.get());
@@ -1834,7 +1843,7 @@ SQLSMALLINT get_resultset_meta_data(_Inout_ sqlsrv_stmt * stmt)
         throw;
     }
 
-    SQLSRV_ASSERT(stmt->current_meta_data.size() == num_cols, "Meta data vector out of sync" );
+    SQLSRV_ASSERT(static_cast<SQLSMALLINT>(stmt->current_meta_data.size()) == num_cols, "Meta data vector out of sync" );
 
     return num_cols;
 }
@@ -1881,7 +1890,7 @@ void fetch_fields_common( _Inout_ ss_sqlsrv_stmt* stmt, _In_ zend_long fetch_typ
     for( int i = 0; i < num_cols; ++i ) {
         SQLLEN field_len = -1;
 
-        core_sqlsrv_get_field( stmt, i, sqlsrv_php_type, true /*prefer string*/,
+        core_sqlsrv_get_field( stmt, static_cast<SQLUSMALLINT>(i), sqlsrv_php_type, true /*prefer string*/,
                                     field_value, &field_len, false /*cache_field*/, &sqlsrv_php_type_out );
 
         zval field;

--- a/source/sqlsrv/stmt.cpp
+++ b/source/sqlsrv/stmt.cpp
@@ -1551,7 +1551,7 @@ void convert_to_zval( _Inout_ sqlsrv_stmt* stmt, _In_ SQLSRV_PHPTYPE sqlsrv_php_
 // put in the column size and scale/decimal digits of the sql server type
 // these values are taken from the MSDN page at http://msdn2.microsoft.com/en-us/library/ms711786(VS.85).aspx
 // for SQL_VARBINARY, SQL_VARCHAR, and SQL_WLONGVARCHAR types, see https://msdn.microsoft.com/en-CA/library/ms187993.aspx
-bool determine_column_size_or_precision( sqlsrv_stmt const* stmt, _In_ sqlsrv_sqltype sqlsrv_type, _Inout_ SQLULEN* column_size,
+bool determine_column_size_or_precision( sqlsrv_stmt const* /*stmt*/, _In_ sqlsrv_sqltype sqlsrv_type, _Inout_ SQLULEN* column_size,
                                          _Out_ SQLSMALLINT* decimal_digits )
 {
     *decimal_digits = 0;

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -931,10 +931,12 @@ bool handle_errors_and_warnings( _Inout_ sqlsrv_context& ctx, _Inout_ zval* repo
 // see RINIT in init.cpp for information about which errors are ignored.
 bool ignore_warning( _In_ char* sql_state, _In_ int native_code )
 {
-	zend_ulong index = -1;
+	zend_ulong index = 0;
 	zend_string* key = NULL;
 	void* error_temp = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
 	ZEND_HASH_FOREACH_KEY_PTR( g_ss_warnings_to_ignore_ht, index, key, error_temp ) {
 		sqlsrv_error* error = static_cast<sqlsrv_error*>( error_temp );
 		if (NULL == error) {
@@ -946,6 +948,7 @@ bool ignore_warning( _In_ char* sql_state, _In_ int native_code )
 			return true;
 		}
 	} ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
     return false;
 }
@@ -968,10 +971,12 @@ bool sqlsrv_merge_zend_hash( _Inout_ zval* dest_z, zval const* src_z )
     }
 
     HashTable* src_ht = Z_ARRVAL_P( src_z );
-	zend_ulong index = -1;
+	zend_ulong index = 0;
 	zend_string* key = NULL;
 	zval* value_z = NULL;
 
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from ZEND_HASH_FOREACH macro
 	ZEND_HASH_FOREACH_KEY_VAL( src_ht, index, key, value_z ) {
 		if ( !value_z ) {
 			zend_hash_apply( Z_ARRVAL_P(dest_z), sqlsrv_merge_zend_hash_dtor );
@@ -986,6 +991,7 @@ bool sqlsrv_merge_zend_hash( _Inout_ zval* dest_z, zval const* src_z )
 		}
 		Z_TRY_ADDREF_P( value_z );
 	} ZEND_HASH_FOREACH_END();
+#pragma warning(pop)
 
     return true;
 }

--- a/source/sqlsrv/util.cpp
+++ b/source/sqlsrv/util.cpp
@@ -565,7 +565,10 @@ PHP_FUNCTION( sqlsrv_errors )
 		zval_ptr_dtor(&err_z);
 		RETURN_NULL();
 	}
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant - from RETURN_ZVAL macro
 	RETURN_ZVAL( &err_z, 1, 1 );
+#pragma warning(pop)
 }
 
 // sqlsrv_configure( string $setting, mixed $value )


### PR DESCRIPTION
This pull request mainly focuses on improving type safety and code correctness across the PDO SQLSRV driver codebase, especially in handling integer conversions, suppressing compiler warnings, and using proper unused parameter macros. The changes also increase warning levels for the build and update some function signatures for clarity.

Type safety and integer conversions:

* Updated multiple assignments and function calls to use explicit `static_cast` for integer types, improving type safety and preventing potential bugs in `pdo_dbh.cpp` and `pdo_stmt.cpp`. 

Compiler warnings and build improvements:

* Increased warning level and enabled warnings-as-errors in build flags for `pdo_sqlsrv` (`/W4 /WX`), and suppressed constant conditional warnings in `validate_stmt_options` for compatibility with the ZEND_HASH_FOREACH macro.
* Improved use of `SQLSRV_UNUSED` macro for unused parameters in lifecycle functions, reducing compiler warnings and clarifying intent in `pdo_init.cpp`. 

Function signatures and parameter handling:

* Updated function signatures to clarify unused parameters and improve readability, such as marking parameters as unused and using lambda for `tolower` transformation in `pdo_dbh.cpp` and `pdo_stmt.cpp`.

Consistency and correctness in buffer and variable naming:

* Improved variable naming for buffer lengths and value lengths in parser functions, and corrected logic for handling option keys in statement option validation.

These changes collectively improve the reliability, maintainability, and correctness of the PDO SQLSRV driver codebase.