### PR TITLE
Release 5.13.0 GA - update version, changelog, and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
-## 5.13.0-beta1 - 2026-01-30
+## 5.13.0 - 2026-02-27
 Updated PECL release packages. Here is the list of updates:
 
 ### Added
-- Support for PHP 8.4
+- Support for PHP 8.4 and PHP 8.5
 - Support for Windows Server 2025
 - Support for Ubuntu 24.04
 - Support for Debian 12 and 13
@@ -22,9 +22,16 @@ Updated PECL release packages. Here is the list of updates:
 - Support for Debian 10
 - Support for macOS 11 and 12
 
+### Changed
+- Refactored build scripts for safety, error handling, and command injection prevention ([PR #1551](https://github.com/microsoft/msphpsql/pull/1551), [PR #1552](https://github.com/microsoft/msphpsql/pull/1552))
+
+
 ### Fixed
 - Fixed segfault when connecting to Fabric ([PR #1549](https://github.com/microsoft/msphpsql/pull/1549))
 - Enhanced error reporting in PDO driver when ODBC diagnostic retrieval fails ([PR #1549](https://github.com/microsoft/msphpsql/pull/1549))
+- Fixed critical memory safety bugs in encoding conversion - NULL pointer dereference and uninitialized pointer return ([PR #1555](https://github.com/microsoft/msphpsql/pull/1555))
+- Removed lingering error2 reference from failure block in CI pipeline ([PR #1568](https://github.com/microsoft/msphpsql/pull/1568))
+- Fixed PHP 8.5 compatibility issues in tests and CI pipeline ([PR #1569](https://github.com/microsoft/msphpsql/pull/1569))
 
 ### Limitations
 - No support for inout / output params when using sql_variant type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ Updated PECL release packages. Here is the list of updates:
 - Support for PHP 8.4 and PHP 8.5
 - Support for Windows Server 2025
 - Support for Ubuntu 24.04
-- Support for Debian 12 and 13
-- Support for Red Hat 9
-- Support for Alpine 3.21, 3.22, and 3.23
-- Support for macOS 14, 15, and 26
+- Support for Debian 11, 12, and 13
+- Support for Red Hat 9 and 10
+- Support for Alpine 3.20, 3.21, 3.22, and 3.23
+- Support for macOS 15 and 26
 
 ### Removed
-- Support for PHP 8.1
+- Support for PHP 8.1 and 8.2
 - Support for Windows 10, Server 2012, and Server 2012 R2
 - Support for Ubuntu 20.04
 - Support for Debian 10
-- Support for macOS 11 and 12
+- Support for Red Hat 7
+- Support for SUSE Linux 12
+- Support for Alpine 3.16, 3.17, 3.18, and 3.19
+- Support for macOS 11, 12, and 13
 
 ### Changed
 - Refactored build scripts for safety, error handling, and command injection prevention ([PR #1551](https://github.com/microsoft/msphpsql/pull/1551), [PR #1552](https://github.com/microsoft/msphpsql/pull/1552))

--- a/Linux-mac-install.md
+++ b/Linux-mac-install.md
@@ -1,7 +1,7 @@
 # Linux and macOS Installation Tutorial for the Microsoft Drivers for PHP for SQL Server
 The following instructions assume a clean environment and show how to install PHP 8.4, the Microsoft ODBC driver, the Apache web server, and the Microsoft Drivers for PHP for SQL Server on Ubuntu, RedHat, Debian, Suse, Alpine, and macOS. These instructions advise installing the drivers using PECL, but you can also download the prebuilt binaries from the [Microsoft Drivers for PHP for SQL Server](https://github.com/Microsoft/msphpsql/releases) Github project page and install them following the instructions in [Loading the Microsoft Drivers for PHP for SQL Server](https://docs.microsoft.com/sql/connect/php/loading-the-php-sql-driver). For an explanation of extension loading and why we do not add the extensions to php.ini, see the section on [loading the drivers](https://docs.microsoft.com/sql/connect/php/loading-the-php-sql-driver#loading-the-driver-at-php-startup).
 
-The following instructions install PHP 8.4 by default using `pecl install`, if the PHP 8.4 packages are available. You may need to run `pecl channel-update pecl.php.net` first. Note that some supported Linux distros may default to older PHP versions -- please see the notes at the beginning of each section to install PHP 8.2 or 8.3 instead.
+The following instructions install PHP 8.4 by default using `pecl install`, if the PHP 8.4 packages are available. You may need to run `pecl channel-update pecl.php.net` first. Note that some supported Linux distros may default to older PHP versions -- please see the notes at the beginning of each section to install PHP 8.3 or 8.5 instead.
 
 Also included are instructions for installing the PHP FastCGI Process Manager, PHP-FPM, on Ubuntu. This is needed if you are using the nginx web server instead of Apache.
 
@@ -20,7 +20,7 @@ While these instructions contain commands to install both SQLSRV and PDO_SQLSRV 
 ## Installing the drivers on Ubuntu
 
 > [!NOTE]
-> To install PHP 8.2 or 8.3, replace 8.4 with 8.2 or 8.3 in the following commands.
+> To install PHP 8.3 or 8.5, replace 8.4 with 8.3 or 8.5 in the following commands.
 
 ### Step 1. Install PHP
 ```bash
@@ -63,7 +63,7 @@ To test your installation, see [Testing your installation](#testing-your-install
 ## Installing the drivers with PHP-FPM on Ubuntu
 
 > [!NOTE]
-> To install PHP 8.2 or 8.3, replace 8.4 with 8.2 or 8.3 in the following commands.
+> To install PHP 8.3 or 8.5, replace 8.4 with 8.3 or 8.5 in the following commands.
 
 ### Step 1. Install PHP
 ```bash
@@ -133,7 +133,7 @@ To test your installation, see [Testing your installation](#testing-your-install
 
 To install PHP on Red Hat 8, run the following:
 > [!NOTE]
-> To install PHP 8.2 or 8.3, replace remi-8.4 with remi-8.2 or remi-8.3 respectively in the following commands.
+> To install PHP 8.3 or 8.5, replace remi-8.4 with remi-8.3 or remi-8.5 respectively in the following commands.
 ```bash
 sudo su
 dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
@@ -149,7 +149,7 @@ dnf install php-pdo php-pear php-devel
 
 To install PHP on Red Hat 9, run the following:
 > [!NOTE]
-> To install PHP 8.2 or 8.3, replace remi-8.4 with remi-8.2 or remi-8.3 respectively in the following commands.
+> To install PHP 8.3 or 8.5, replace remi-8.4 with remi-8.3 or remi-8.5 respectively in the following commands.
 ```bash
 sudo su
 dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
@@ -196,7 +196,7 @@ To test your installation, see [Testing your installation](#testing-your-install
 ## Installing the drivers on Debian
 
 > [!NOTE]
-> To install PHP 8.2 or 8.3, replace 8.4 in the following commands with 8.2 or 8.3.
+> To install PHP 8.3 or 8.5, replace 8.4 in the following commands with 8.3 or 8.5.
 
 ### Step 1. Install PHP
 ```bash
@@ -251,7 +251,7 @@ To test your installation, see [Testing your installation](#testing-your-install
 > In the following instructions, replace `<SuseVersion>` with your version of Suse - if you are using Suse Enterprise Linux 15, it will be SLE_15_SP3 or SLE_15_SP4 (or above). For Suse 12, use SLE_12_SP5 (or above). Not all versions of PHP are available for all versions of Suse Linux - please refer to `http://download.opensuse.org/repositories/devel:/languages:/php` to see which versions of Suse have the default version PHP available, or check `http://download.opensuse.org/repositories/devel:/languages:/php:/` to see which other versions of PHP are available for which versions of Suse.
 
 > [!NOTE]
-> Packages for PHP 8.2 or above may not be available for all versions of Suse. Please check the repositories for the latest available PHP versions.
+> Packages for PHP 8.3 or above may not be available for all versions of Suse. Please check the repositories for the latest available PHP versions.
 
 ### Step 1. Install PHP
 ```bash
@@ -344,7 +344,7 @@ If you do not already have it, install Homebrew as follows:
 > If using Apple Silicon (M1/M2/M3) hardware, please install Homebrew and PHP directly without using the emulator Rosetta 2.
 
 > [!NOTE]
-> To install PHP 8.2 or 8.3, replace php@8.4 with php@8.2 or php@8.3 respectively in the following commands.
+> To install PHP 8.3 or 8.5, replace php@8.4 with php@8.3 or php@8.5 respectively in the following commands.
 
 ### Step 1. Install PHP
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The [Microsoft Drivers for PHP for Microsoft SQL Server][phpdoc] are PHP extensions that allow for the reading and writing of SQL Server data from within PHP scripts. The SQLSRV extension provides a procedural interface while the PDO_SQLSRV extension implements PHP Data Objects (PDO) for accessing data in all editions of SQL Server 2012 and later (including Azure SQL DB). These drivers rely on the [Microsoft ODBC Driver for SQL Server][odbcdoc] to handle the low-level communication with SQL Server.
 
-This release contains the SQLSRV and PDO_SQLSRV drivers for PHP 8.2+ with improvements on both drivers and some limitations. Upcoming [releases][releases] will contain additional functionalities, bug fixes, and more.
+This release contains the SQLSRV and PDO_SQLSRV drivers for PHP 8.3+ with improvements on both drivers and some limitations. Upcoming [releases][releases] will contain additional functionalities, bug fixes, and more.
 
 ## Take our survey
 
@@ -37,8 +37,8 @@ Please follow the [Getting started](https://docs.microsoft.com/sql/connect/php/g
 For full details on the system requirements for the drivers, see the [system requirements](https://docs.microsoft.com/sql/connect/php/system-requirements-for-the-php-sql-driver) on Microsoft Docs.
 
 On the client machine:
-- 8.2.x, 8.3.x, 8.4.x, 8.5.x
-- [Microsoft ODBC Driver 18, 17 or 13][odbcdoc]
+- 8.3.x, 8.4.x, 8.5.x
+- [Microsoft ODBC Driver 18 or 17][odbcdoc]
 - If using a Web server such as Internet Information Services (IIS) or Apache, it must be configured to run PHP
 
 On the server side, Microsoft SQL Server 2012 and above on Windows are supported, as are Microsoft SQL Server 2016 and above on Linux.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please follow the [Getting started](https://docs.microsoft.com/sql/connect/php/g
 For full details on the system requirements for the drivers, see the [system requirements](https://docs.microsoft.com/sql/connect/php/system-requirements-for-the-php-sql-driver) on Microsoft Docs.
 
 On the client machine:
-- 8.2.x, 8.3.x, 8.4.x
+- 8.2.x, 8.3.x, 8.4.x, 8.5.x
 - [Microsoft ODBC Driver 18, 17 or 13][odbcdoc]
 - If using a Web server such as Internet Information Services (IIS) or Apache, it must be configured to run PHP
 

--- a/source/shared/version.h
+++ b/source/shared/version.h
@@ -31,7 +31,7 @@
 #define SQLVERSION_BUILD 0
 
 // For previews, set this constant to 1, 2 and so on. Otherwise, set it to 0
-#define PREVIEW 1
+#define PREVIEW 0
 #define SEMVER_PRERELEASE
 
 // Semantic versioning build metadata, build meta data is not counted in precedence order.


### PR DESCRIPTION
This pull request updates the documentation, changelog, and versioning to reflect support for PHP 8.5 and drops support for older PHP versions and platforms. It also introduces several bug fixes and improvements to build scripts for safety and reliability. The most important changes are summarized below.

**Platform and PHP version support updates:**

* Added support for PHP 8.5 and expanded platform support (Debian 11, Red Hat 10, Alpine 3.20, macOS 15 and 26); dropped support for PHP 8.1 and 8.2, Red Hat 7, SUSE Linux 12, Alpine 3.16–3.19, and macOS 11–13. 
* Updated documentation (`Linux-mac-install.md`, `README.md`) to reflect PHP 8.3 and 8.5 as the minimum supported versions, and revised installation instructions for all platforms accordingly. 

**Build and release improvements:**

* Refactored build scripts to improve safety, error handling, and prevent command injection. 

**Bug fixes and compatibility:**

* Fixed critical memory safety bugs in encoding conversion, removed lingering error references in CI, and resolved PHP 8.5 compatibility issues in tests and CI pipeline. 

**Versioning updates:**

* Updated semantic versioning and removed preview status for the 5.13.0 release.

**Release and changelog updates:**

* Changed release version from `5.13.0-beta1` to `5.13.0` and documented all notable changes, removals, and fixes. 