### PR TITLE
Fix connection options for SQLCMD and BCP in setup_dbs.py

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,10 +140,10 @@ jobs:
       
       # Try to connect
       /opt/homebrew/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 \
-        -U $(uid) -P "$(macpwd)" -C \
+        -U $(uid) -P "$(macpwd)" -No -C \
         -Q "SELECT @@Version" || \
       /usr/local/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 \
-        -U $(uid) -P "$(macpwd)" -C \
+        -U $(uid) -P "$(macpwd)" -No -C \
         -Q "SELECT @@Version"
       
       echo "SQL Server connection verified!"
@@ -264,8 +264,7 @@ jobs:
   #########################################
   - script: |
       set -e
-      cd $(REPO_ROOT)/test
-      
+      cd $(REPO_ROOT)/test/functional/setup
       export TEST_PHP_SQL_SERVER='127.0.0.1'
       export TEST_PHP_SQL_UID='$(uid)'
       export TEST_PHP_SQL_PWD='$(macpwd)'
@@ -273,132 +272,11 @@ jobs:
       # Add sqlcmd and bcp tools to PATH
       export PATH="/opt/homebrew/opt/mssql-tools18/bin:/usr/local/opt/mssql-tools18/bin:$PATH"
       
-      echo "Creating test databases..."
-      echo "sqlcmd path: $(which sqlcmd || echo 'not found')"
-      echo "bcp path: $(which bcp || echo 'not found')"
-      
-      cd functional/setup
-      
-      echo "=== Original setup_dbs.py bcp/sqlcmd lines ==="
-      grep -n "redirect_string\|conn_options" setup_dbs.py || true
-      
-      # Patch setup_dbs.py for ODBC 18 on macOS:
-      # 1. Remove -C from redirect_string (it's a code page flag, not SSL trust)
-      sed -i '' "s/redirect_string = 'bcp {0}..{1} in {2}.dat -f {2}.fmt -q -C'/redirect_string = 'bcp {0}..{1} in {2}.dat -f {2}.fmt -q'/g" setup_dbs.py
-      
-      # 2. Add -u flag to BCP command for trusting self-signed certificates
-      sed -i '' "s/inst_command = redirect_string.format(dbname, tblname, datafile) + conn_options/inst_command = redirect_string.format(dbname, tblname, datafile) + ' -u ' + conn_options/g" setup_dbs.py
-      
-      echo "=== Patched setup_dbs.py ==="
-      grep -n "redirect_string\|inst_command\|executeBulkCopy" setup_dbs.py | head -20 || true
-      
-      # Patch exec_sql_scripts.py - add -C flag to sqlcmd command if not present
-      if grep -q '"-C"' exec_sql_scripts.py; then
-          echo "exec_sql_scripts.py already has -C flag"
-      else
-          sed -i '' 's/"-S", server, "-d", dbname]/"-S", server, "-d", dbname, "-C"]/g' exec_sql_scripts.py 2>/dev/null || true
-      fi
-      
-      cd $(REPO_ROOT)/test
-      
-      # Test sqlcmd connection before setup
-      echo "=== Testing sqlcmd connection with -C flag ==="
-      sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -Q "SELECT @@VERSION" || {
-          echo "ERROR: Cannot connect to SQL Server with sqlcmd"
-          exit 1
-      }
-      
-      # Create databases directly with sqlcmd
-      echo "=== Creating databases directly with sqlcmd ==="
-      sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -Q "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = '$(macOS_sqlsrv_db)') CREATE DATABASE [$(macOS_sqlsrv_db)]" || echo "Warning: sqlsrv_db creation may have failed"
-      sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -Q "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = '$(macOS_pdo_sqlsrv_db)') CREATE DATABASE [$(macOS_pdo_sqlsrv_db)]" || echo "Warning: pdo_sqlsrv_db creation may have failed"
-      
-      # Verify databases exist
-      echo "=== Verifying databases exist ==="
-      sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -Q "SELECT name FROM sys.databases WHERE name IN ('$(macOS_sqlsrv_db)', '$(macOS_pdo_sqlsrv_db)')"
-      
       echo "Setting up database $(macOS_sqlsrv_db)..."
-      cd functional/setup
-      
-      python3 setup_dbs.py -dbname $(macOS_sqlsrv_db) 2>&1 || {
-          echo "WARNING: setup_dbs.py failed for $(macOS_sqlsrv_db)"
-          echo "Creating tables manually with sqlcmd..."
-          sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$(macOS_sqlsrv_db)" -Q "
-          IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'test_types')
-          CREATE TABLE test_types (
-              id INT IDENTITY(1,1) PRIMARY KEY,
-              c1_int INT, c2_smallint SMALLINT, c3_tinyint TINYINT, c4_bit BIT, c5_bigint BIGINT,
-              c6_decimal DECIMAL(28,4), c7_numeric NUMERIC(32,4), c8_float FLOAT, c9_real REAL,
-              c10_date DATE, c11_datetime DATETIME, c12_datetime2 DATETIME2,
-              c13_datetimeoffset DATETIMEOFFSET, c14_time TIME,
-              c15_char CHAR(100), c16_varchar VARCHAR(100), c17_text TEXT,
-              c18_nchar NCHAR(100), c19_nvarchar NVARCHAR(100), c20_ntext NTEXT,
-              c21_binary BINARY(100), c22_varbinary VARBINARY(100), c23_image IMAGE,
-              c24_uniqueidentifier UNIQUEIDENTIFIER, c25_xml XML, c26_money MONEY, c27_smallmoney SMALLMONEY
-          );" || echo "WARNING: Manual table creation failed"
-      }
+      python3 setup_dbs.py -dbname $(macOS_sqlsrv_db)
       
       echo "Setting up database $(macOS_pdo_sqlsrv_db)..."
-      python3 setup_dbs.py -dbname $(macOS_pdo_sqlsrv_db) 2>&1 || {
-          echo "WARNING: setup_dbs.py failed for $(macOS_pdo_sqlsrv_db)"
-          echo "Creating tables manually with sqlcmd..."
-          sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$(macOS_pdo_sqlsrv_db)" -Q "
-          IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'test_types')
-          CREATE TABLE test_types (
-              id INT IDENTITY(1,1) PRIMARY KEY,
-              c1_int INT, c2_smallint SMALLINT, c3_tinyint TINYINT, c4_bit BIT, c5_bigint BIGINT,
-              c6_decimal DECIMAL(28,4), c7_numeric NUMERIC(32,4), c8_float FLOAT, c9_real REAL,
-              c10_date DATE, c11_datetime DATETIME, c12_datetime2 DATETIME2,
-              c13_datetimeoffset DATETIMEOFFSET, c14_time TIME,
-              c15_char CHAR(100), c16_varchar VARCHAR(100), c17_text TEXT,
-              c18_nchar NCHAR(100), c19_nvarchar NVARCHAR(100), c20_ntext NTEXT,
-              c21_binary BINARY(100), c22_varbinary VARBINARY(100), c23_image IMAGE,
-              c24_uniqueidentifier UNIQUEIDENTIFIER, c25_xml XML, c26_money MONEY, c27_smallmoney SMALLMONEY
-          );" || echo "WARNING: Manual table creation failed"
-      }
-      
-      cd $(REPO_ROOT)/test
-      
-      # Verify test tables were created
-      echo ""
-      echo "=== Verifying test tables exist ==="
-      sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$(macOS_sqlsrv_db)" -Q "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME IN ('cd_info', 'test_types', 'tracks')" || true
-      sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$(macOS_pdo_sqlsrv_db)" -Q "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME IN ('cd_info', 'test_types', 'tracks')" || true
-      
-      # Insert essential test data via sqlcmd (BCP fallback)
-      echo ""
-      echo "=== Inserting test data via sqlcmd (BCP fallback) ==="
-      for DB in "$(macOS_sqlsrv_db)" "$(macOS_pdo_sqlsrv_db)"; do
-          echo "Inserting data into $DB..."
-          
-          sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$DB" -Q "
-          IF NOT EXISTS (SELECT 1 FROM test_types)
-          BEGIN
-              INSERT INTO test_types DEFAULT VALUES;
-              INSERT INTO test_types DEFAULT VALUES;
-              INSERT INTO test_types DEFAULT VALUES;
-          END" || echo "WARNING: Could not insert test_types data into $DB"
-          
-          sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$DB" -Q "
-          IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'tracks')
-             AND NOT EXISTS (SELECT 1 FROM tracks)
-          BEGIN
-              INSERT INTO tracks (asin, track) VALUES ('B00004XOO7', 1);
-              INSERT INTO tracks (asin, track) VALUES ('B00004XOO7', 2);
-              INSERT INTO tracks (asin, track) VALUES ('B00008WT5G', 1);
-          END" 2>/dev/null || echo "Note: tracks insert skipped"
-      done
-      
-      # Create stored procedures
-      echo ""
-      echo "=== Creating stored procedures ==="
-      for DB in "$(macOS_sqlsrv_db)" "$(macOS_pdo_sqlsrv_db)"; do
-          sqlcmd -C -S "$TEST_PHP_SQL_SERVER" -U "$TEST_PHP_SQL_UID" -P "$TEST_PHP_SQL_PWD" -d "$DB" -Q "
-          IF NOT EXISTS (SELECT * FROM sys.procedures WHERE name = 'test_out')
-          BEGIN
-              EXEC('CREATE PROCEDURE test_out @p1 INT, @p2 INT OUTPUT AS SET @p2 = @p1 + @p1 + @p1')
-          END" || echo "WARNING: Could not create stored procedure in $DB"
-      done
+      python3 setup_dbs.py -dbname $(macOS_pdo_sqlsrv_db)
       
       echo "Test databases created!"
     displayName: 'Setup Test Databases'

--- a/test/functional/setup/setup_dbs.py
+++ b/test/functional/setup/setup_dbs.py
@@ -25,28 +25,28 @@ def _is_mssqltools_v18():
 # optional + trust-server-certificate so sqlcmd/bcp work against servers
 # without a valid TLS certificate. Empty strings for older tools.
 _v18 = _is_mssqltools_v18()
-_encrypt_opt_sqlcmd = ' -Yo -C' if _v18 else ''
+_encrypt_opt_sqlcmd = ' -No -C' if _v18 else ''
 _encrypt_opt_bcp   = ' -Yo -u' if _v18 else ''
 
-def setupTestDatabase(conn_options, dbname, azure):
+def setupTestDatabase(conn_options_sqlcmd, dbname, azure):
     sqlFiles = ['test_types.sql', '168256.sql', 'cd_info.sql', 'tracks.sql']
 
     for sqlFile in sqlFiles:
-        executeSQLscript(sqlFile, conn_options, dbname)
+        executeSQLscript(sqlFile, conn_options_sqlcmd, dbname)
 
-def populateTables(conn_options, dbname):
-    executeBulkCopy(conn_options, dbname, 'cd_info', 'cd_info')
-    executeBulkCopy(conn_options, dbname, 'tracks', 'tracks')
-    executeBulkCopy(conn_options, dbname, 'test_streamable_types', 'test_streamable_types')
-    executeBulkCopy(conn_options, dbname, '159137', 'xml')
-    executeBulkCopy(conn_options, dbname, '168256', '168256')
+def populateTables(conn_options_bcp, dbname):
+    executeBulkCopy(conn_options_bcp, dbname, 'cd_info', 'cd_info')
+    executeBulkCopy(conn_options_bcp, dbname, 'tracks', 'tracks')
+    executeBulkCopy(conn_options_bcp, dbname, 'test_streamable_types', 'test_streamable_types')
+    executeBulkCopy(conn_options_bcp, dbname, '159137', 'xml')
+    executeBulkCopy(conn_options_bcp, dbname, '168256', '168256')
 
-def executeBulkCopy(conn_options, dbname, tblname, datafile):
-    redirect_string = 'bcp {0}..{1} in {2}.dat -f {2}.fmt -q' + _encrypt_opt_bcp
-    inst_command = redirect_string.format(dbname, tblname, datafile) + conn_options
+def executeBulkCopy(conn_options_bcp, dbname, tblname, datafile):
+    redirect_string = 'bcp {0}..{1} in {2}.dat -f {2}.fmt -q'
+    inst_command = redirect_string.format(dbname, tblname, datafile) + conn_options_bcp
     executeCommmand(inst_command)
 
-def setupAE(conn_options, dbname):
+def setupAE(conn_options_sqlcmd, dbname):
     if (platform.system() == 'Windows'):
         # import self signed certificate
         inst_command = "certutil -user -p '' -importPFX My PHPcert.pfx NoRoot"
@@ -54,7 +54,7 @@ def setupAE(conn_options, dbname):
         inst_command = "certutil -user -p '' -importPFX My AEV2Cert.pfx NoRoot"
         executeCommmand(inst_command)
         # create Column Master Key and Column Encryption Key
-        script_command = 'sqlcmd -I ' + conn_options + ' -i ae_keys.sql -d ' + dbname
+        script_command = 'sqlcmd -I ' + conn_options_sqlcmd + ' -i ae_keys.sql -d ' + dbname
         executeCommmand(script_command)
 
 if __name__ == '__main__':
@@ -77,20 +77,22 @@ if __name__ == '__main__':
 
     current_working_dir=os.getcwd()
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
-    conn_options = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + _encrypt_opt_sqlcmd + ' '
+    base_conn = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + ' '
+    conn_options_sqlcmd = base_conn + _encrypt_opt_sqlcmd
+    conn_options_bcp = base_conn + _encrypt_opt_bcp
 
     # In Azure, assume an empty test database has been created using Azure portal
     if (args.AZURE.lower() == 'no'):
-        manageTestDB('create_db.sql', conn_options, args.DBNAME)
+        manageTestDB('create_db.sql', conn_options_sqlcmd, args.DBNAME)
 
     print("About to set up databases...\n")
     # create tables in the new database
-    setupTestDatabase(conn_options, args.DBNAME, args.AZURE)
+    setupTestDatabase(conn_options_sqlcmd, args.DBNAME, args.AZURE)
     print("About to populate tables...\n")
     # populate these tables
-    populateTables(conn_options, args.DBNAME)
+    populateTables(conn_options_bcp, args.DBNAME)
     print("About to set up encryption...\n")
     # setup AE (certificate, column master key and column encryption key)
-    setupAE(conn_options, args.DBNAME)
+    setupAE(conn_options_sqlcmd, args.DBNAME)
 
     os.chdir(current_working_dir)


### PR DESCRIPTION
Update the test database setup process for SQL Server on macOS.

* Updated the `sqlcmd` flags in `azure-pipelines.yml` to use `-No`.
* Refactored connection option handling in `setup_dbs.py` to distinguish between options for `sqlcmd` and `bcp`, passing the appropriate flags to each tool.
* Simplified the test database setup script in `azure-pipelines.yml` by removing fallback/duplicated manual table creation and data insertion logic, relying solely on `setup_dbs.py` for database setup.