### PR TITLE
Fix Encrypt=no for ODBC 18 support in test config

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -340,15 +340,6 @@ jobs:
       
       echo "Configuring skip files for tests that require unavailable features..."
       
-      # Skip HGS/enclave tests (secure enclaves not available in Docker)
-      for skipfile in sqlsrv/skipif_not_hgs.inc pdo_sqlsrv/skipif_not_hgs.inc; do
-        if [[ -f "$skipfile" ]]; then
-          cp "$skipfile" "${skipfile}.bak"
-          echo '<?php die("skip Secure enclave not configured for macOS CI environment"); ?>' > "$skipfile"
-          echo "Modified $skipfile to always skip"
-        fi
-      done
-      
       # Skip Chinese locale test (has macOS-specific encoding issues)
       if [[ -f "pdo_sqlsrv/pdo_ansi_locale_zh.phpt" ]]; then
         mv pdo_sqlsrv/pdo_ansi_locale_zh.phpt pdo_sqlsrv/pdo_ansi_locale_zh.phpt.skip || true
@@ -369,14 +360,6 @@ jobs:
         echo "Skipped test_stream_large_data.phpt (times out on macOS CI)"
       fi
       
-      # Skip tests with ODBC 18-specific pattern mismatches
-      for skiptest in pdo_sqlsrv/pdo_construct_dsn_error.phpt pdo_sqlsrv/pdo_utf8_conn.phpt; do
-        if [[ -f "$skiptest" ]]; then
-          mv "$skiptest" "${skiptest}.skip" || true
-          echo "Skipped $skiptest (ODBC 18 pattern mismatch)"
-        fi
-      done
-      
       # Skip tests that cause BORKED errors
       for borktest in pdo_sqlsrv/pdo_azure_ad_access_token.phpt pdo_sqlsrv/pdo_connect_encrypt_attributes.phpt; do
         if [[ -f "$borktest" ]]; then
@@ -392,20 +375,6 @@ jobs:
           echo "Skipped $pooltest (requires ODBC pooling config)"
         fi
       done
-      
-      # Skip Azure Key Vault tests (require AKV credentials)
-      for akvtest in pdo_sqlsrv/pdo_ae_azure_key_vault_keywords.phpt pdo_sqlsrv/pdo_ae_insert_datetime_encrypted.phpt sqlsrv/sqlsrv_ae_azure_key_vault_keywords.phpt; do
-        if [[ -f "$akvtest" ]]; then
-          mv "$akvtest" "${akvtest}.skip" || true
-          echo "Skipped $akvtest (requires AKV credentials)"
-        fi
-      done
-      
-      # Skip PDO95_Extend2 test
-      if [[ -f "pdo_sqlsrv/PDO95_Extend2.phpt" ]]; then
-        mv pdo_sqlsrv/PDO95_Extend2.phpt pdo_sqlsrv/PDO95_Extend2.phpt.skip || true
-        echo "Skipped PDO95_Extend2.phpt"
-      fi
       
       echo "Skip files configured"
     displayName: 'Configure Test Skip Files'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -306,42 +306,6 @@ jobs:
       sed -i '' -e "s/TARGET_USERNAME/${SQL_USER}/g" pdo_sqlsrv/MsSetup.inc
       sed -i '' -e "s/TARGET_PASSWORD/${SQL_PWD}/g" pdo_sqlsrv/MsSetup.inc
       
-      # Add TrustServerCertificate for ODBC 18
-      echo "Adding TrustServerCertificate for ODBC 18 compatibility..."
-      
-      # sqlsrv: Add TrustServerCertificate => 1
-      sed -i '' -e 's/"Encrypt" => \$encrypt)/"Encrypt" => \$encrypt, "TrustServerCertificate" => 1)/g' sqlsrv/MsSetup.inc
-      
-      # pdo_sqlsrv: Add TrustServerCertificate=1 to DSN
-      sed -i '' -e 's/Encrypt=\$encrypt;/Encrypt=\$encrypt;TrustServerCertificate=1;/g' pdo_sqlsrv/MsCommon.inc
-      sed -i '' -e 's/Encrypt=\$encrypt;/Encrypt=\$encrypt;TrustServerCertificate=1;/g' pdo_sqlsrv/MsCommon_mid-refactor.inc
-      
-      # Update MsSetup.inc for PDO
-      sed -i '' -e "s/\$connectionOptions = array();/\$connectionOptions = array('TrustServerCertificate' => 1);/g" pdo_sqlsrv/MsSetup.inc
-      
-      # Additional TrustServerCertificate patterns
-      sed -i '' -e 's/Database=\$databaseName"/Database=\$databaseName;TrustServerCertificate=1"/g' pdo_sqlsrv/MsCommon.inc
-      sed -i '' -e 's/Database=\$databaseName"/Database=\$databaseName;TrustServerCertificate=1"/g' pdo_sqlsrv/MsCommon_mid-refactor.inc
-      
-      # Patch ALL PDO test files for TrustServerCertificate
-      echo "Patching all PDO test files for TrustServerCertificate..."
-      for f in pdo_sqlsrv/*.phpt pdo_sqlsrv/*.php pdo_sqlsrv/*.inc; do
-        if [[ -f "$f" ]]; then
-          sed -i '' -e 's/;Database=\([^;"]*\)"/;Database=\1;TrustServerCertificate=1"/g' "$f" 2>/dev/null || true
-          sed -i '' -e 's/sqlsrv:Server=/sqlsrv:TrustServerCertificate=1;Server=/g' "$f" 2>/dev/null || true
-          sed -i '' -e "s/sqlsrv:server=/sqlsrv:TrustServerCertificate=1;server=/gi" "$f" 2>/dev/null || true
-        fi
-      done
-      
-      # Patch sqlsrv test files
-      for f in sqlsrv/*.phpt sqlsrv/*.php sqlsrv/*.inc; do
-        if [[ -f "$f" ]]; then
-          sed -i '' -e "s/array(\"Database\"/array(\"TrustServerCertificate\" => 1, \"Database\"/g" "$f" 2>/dev/null || true
-          sed -i '' -e "s/array('Database'/array('TrustServerCertificate' => 1, 'Database'/g" "$f" 2>/dev/null || true
-        fi
-      done
-      
-      echo ""
       echo "=== sqlsrv/MsSetup.inc (first 50 lines) ==="
       head -50 sqlsrv/MsSetup.inc
       echo ""
@@ -478,7 +442,7 @@ jobs:
       echo "Verifying database connection before tests..."
       $PHP_BIN -c $PHP_INI -r "
       \$server = '127.0.0.1';
-      \$options = array('Database' => '$(macOS_sqlsrv_db)', 'UID' => '$(uid)', 'PWD' => '$(macpwd)', 'TrustServerCertificate' => 1, 'Encrypt' => 'no');
+      \$options = array('Database' => '$(macOS_sqlsrv_db)', 'UID' => '$(uid)', 'PWD' => '$(macpwd)', 'Encrypt' => 'no');
       \$conn = sqlsrv_connect(\$server, \$options);
       if (\$conn === false) {
           print_r(sqlsrv_errors());
@@ -539,12 +503,11 @@ jobs:
       
       cp *.log $(Build.SourcesDirectory)/out/Logs/ 2>/dev/null || true
       
+      for f in sqlsrv/*.diff; do ls $f 2>/dev/null; cat $f 2>/dev/null; echo ''; done || true
+      for f in pdo_sqlsrv/*.diff; do ls $f 2>/dev/null; cat $f 2>/dev/null; echo ''; done || true
       # Generate JUnit XML
-      if [[ -f output.py ]]; then
-          python3 output.py || true
-      fi
-      
-      ls -l *.xml 2>/dev/null || echo "No XML files generated"
+      python3 output.py
+      ls -l *.xml
     displayName: 'Process Test Logs'
     condition: always()
 
@@ -769,7 +732,6 @@ jobs:
       echo "================================="
     displayName: 'Show ODBC Driver version being used'
 
-  # Full test runs - commented out for debugging
   - script: |
       cd $(Build.SourcesDirectory)/test/functional/sqlsrv
       export MSSQL_SERVER='$(server)'

--- a/test/Performance/lib/PDOSqlsrvUtil.php
+++ b/test/Performance/lib/PDOSqlsrvUtil.php
@@ -12,7 +12,7 @@ class PDOSqlsrvUtil
         require dirname(__FILE__).DIRECTORY_SEPARATOR.'connect.php';
         try
         {
-            $conn = new PDO( "sqlsrv:Server=$server; Database=$database; ConnectionPooling=$pooling; MultipleActiveResultSets=$mars" , $uid, $pwd );       
+            $conn = new PDO( "sqlsrv:Server=$server; Database=$database; Encrypt=$encrypt; ConnectionPooling=$pooling; MultipleActiveResultSets=$mars" , $uid, $pwd );       
             $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
             return $conn;
         }

--- a/test/functional/pdo_sqlsrv/MsCommon.inc
+++ b/test/functional/pdo_sqlsrv/MsCommon.inc
@@ -524,7 +524,7 @@ function PDOConnect($className, $serverName, $user, $pwd, $exitMode)
     {
         // simply use $databaseName from MsSetup.inc to facilitate testing in Azure,  
         // which does not support switching databases
-        $conn = new $className("sqlsrv:Server=$serverName;Database=$databaseName", $user, $pwd, $connectionOptions);
+        $conn = new $className("sqlsrv:Server=$serverName;Database=$databaseName;Driver=$driver;Encrypt=$encrypt", $user, $pwd, $connectionOptions);
         $conn->setAttribute(PDO::SQLSRV_ATTR_ENCODING, PDO::SQLSRV_ENCODING_SYSTEM);
     }
     catch (PDOException $e)

--- a/test/functional/pdo_sqlsrv/MsCommon_mid-refactor.inc
+++ b/test/functional/pdo_sqlsrv/MsCommon_mid-refactor.inc
@@ -844,7 +844,7 @@ function PDOConnect($className, $serverName, $user, $pwd, $exitMode)
     try {
         // simply use $databaseName from MsSetup.inc to facilitate testing in Azure,
         // which does not support switching databases
-        $conn = new $className("sqlsrv:Server=$serverName;Database=$databaseName", $user, $pwd, $connectionOptions);
+        $conn = new $className("sqlsrv:Server=$serverName;Database=$databaseName;Driver=$driver;Encrypt=$encrypt", $user, $pwd, $connectionOptions);
         $conn->setAttribute(PDO::SQLSRV_ATTR_ENCODING, PDO::SQLSRV_ENCODING_SYSTEM);
     } catch (PDOException $e) {
         $conn = null;

--- a/test/functional/pdo_sqlsrv/PDO95_Extend2.phpt
+++ b/test/functional/pdo_sqlsrv/PDO95_Extend2.phpt
@@ -26,7 +26,7 @@ function Extend()
 
     // simply use $databaseName from MsSetup.inc to facilitate testing in Azure,  
     // which does not support switching databases
-    $conn2 = new ExPDO("sqlsrv:Server=$server;Database=$databaseName", $uid, $pwd);
+    $conn2 = new ExPDO("sqlsrv:Server=$server;Database=$databaseName;Encrypt=$encrypt", $uid, $pwd);
     // With PHP 8.0 the default is PDO::ERRMODE_EXCEPTION rather than PDO::ERRMODE_SILENT
     $conn2->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
     

--- a/test/functional/pdo_sqlsrv/PDO95_Extend2_p7.phpt
+++ b/test/functional/pdo_sqlsrv/PDO95_Extend2_p7.phpt
@@ -26,7 +26,7 @@ function Extend()
 
     // simply use $databaseName from MsSetup.inc to facilitate testing in Azure,  
     // which does not support switching databases
-    $conn2 = new ExPDO("sqlsrv:Server=$server;Database=$databaseName", $uid, $pwd);
+    $conn2 = new ExPDO("sqlsrv:Server=$server;Database=$databaseName;Encrypt=$encrypt", $uid, $pwd);
     // With PHP 8.0 the default is PDO::ERRMODE_EXCEPTION rather than PDO::ERRMODE_SILENT
     $conn2->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
     

--- a/test/functional/pdo_sqlsrv/pdo_ae_azure_key_vault_client_secret.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_ae_azure_key_vault_client_secret.phpt
@@ -12,7 +12,7 @@ $dataTypes = array("char(".SHORT_STRSIZE.")", "varchar(".SHORT_STRSIZE.")", "nva
                     "decimal", "float", "real", "bigint", "int", "bit"
                     );
 
-$connectionOptions = "sqlsrv:Server=$server;Database=$databaseName";
+$connectionOptions = "sqlsrv:Server=$server;Database=$databaseName;Encrypt=$encrypt";
 
 $connectionOptions .= ";ColumnEncryption=enabled";
 $connectionOptions .= ";KeyStoreAuthentication=KeyVaultClientSecret";

--- a/test/functional/pdo_sqlsrv/pdo_ae_azure_key_vault_keywords.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_ae_azure_key_vault_keywords.phpt
@@ -50,7 +50,7 @@ $tableName = "akv_comparison_table";
 
 // First determine if the server is AE v2 enabled
 $isEnclaveEnabled = false;
-$connectionOptions = "sqlsrv:Server=$server;Database=$databaseName";
+$connectionOptions = "sqlsrv:Server=$server;Database=$databaseName;Encrypt=$encrypt";
 
 $conn = new PDO($connectionOptions, $uid, $pwd);
 if (!$conn) {
@@ -79,7 +79,7 @@ for ($i = 0; $i < sizeof($columnEncryption); ++$i) {
     for ($j = 0; $j < sizeof($keyStoreAuthentication); ++$j) {
         for ($k = 0; $k < sizeof($keyStorePrincipalId); ++$k) {
             for ($m = 0; $m < sizeof($keyStoreSecret); ++$m) {
-                $connectionOptions = "sqlsrv:Server=$server;Database=$databaseName";
+                $connectionOptions = "sqlsrv:Server=$server;Database=$databaseName;Encrypt=$encrypt";
 
                 if (!empty($columnEncryption[$i])) {
                     $connectionOptions .= ";ColumnEncryption=".$columnEncryption[$i];

--- a/test/functional/pdo_sqlsrv/pdo_ae_azure_key_vault_username_password.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_ae_azure_key_vault_username_password.phpt
@@ -12,7 +12,7 @@ $dataTypes = array("char(".SHORT_STRSIZE.")", "varchar(".SHORT_STRSIZE.")", "nva
                     "decimal", "float", "real", "bigint", "int", "bit"
                     );
 
-$connectionOptions = "sqlsrv:Server=$server;Database=$databaseName";
+$connectionOptions = "sqlsrv:Server=$server;Database=$databaseName;Encrypt=$encrypt";
 
 $connectionOptions .= ";ColumnEncryption=enabled";
 $connectionOptions .= ";KeyStoreAuthentication=KeyVaultPassword";

--- a/test/functional/pdo_sqlsrv/pdo_ae_insert_datetime_encrypted.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_ae_insert_datetime_encrypted.phpt
@@ -45,7 +45,7 @@ function createTablePlainQuery($conn, $tableName, $columns)
 try {
     // This test requires to connect with the Always Encrypted feature
     // First check if the system is qualified to run this test
-    $dsn = "sqlsrv:Server=$server; Database=$databaseName;";
+    $dsn = "sqlsrv:Server=$server; Database=$databaseName;Encrypt=$encrypt;";
     $conn = new PDO($dsn, $uid, $pwd);
     $qualified = isAEQualified($conn) && (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN');
 

--- a/test/functional/pdo_sqlsrv/pdo_aev2_keywords.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_aev2_keywords.phpt
@@ -17,7 +17,7 @@ require_once("AE_v2_values.inc");
 require_once("pdo_AE_functions.inc");
 
 // Test with random nonsense. Connection should fail.
-$options = "sqlsrv:Server=$server;database=$databaseName;ColumnEncryption=xyz";
+$options = "sqlsrv:Server=$server;database=$databaseName;Encrypt=$encrypt;ColumnEncryption=xyz";
 
 try {
     $conn = new PDO($options, $uid, $pwd);
@@ -31,7 +31,7 @@ try {
 // Insert a rogue 'x' into the protocol part of the attestation.
 $comma = strpos($attestation, ',');
 $badProtocol = substr_replace($attestation, 'x', $comma, 0);
-$options = "sqlsrv:Server=$server;database=$databaseName;ColumnEncryption=$badProtocol";
+$options = "sqlsrv:Server=$server;database=$databaseName;Encrypt=$encrypt;ColumnEncryption=$badProtocol";
 
 try {
     $conn = new PDO($options, $uid, $pwd);
@@ -44,7 +44,7 @@ try {
 // Test with good protocol and incorrect attestation URL. Connection should succeed
 // because the URL is only checked when an enclave computation is attempted.
 $badURL = substr_replace($attestation, 'x', $comma+1, 0);
-$options = "sqlsrv:Server=$server;database=$databaseName;ColumnEncryption=$badURL";
+$options = "sqlsrv:Server=$server;database=$databaseName;Encrypt=$encrypt;ColumnEncryption=$badURL";
 
 try {
     $conn = new PDO($options, $uid, $pwd);

--- a/test/functional/pdo_sqlsrv/pdo_construct_dsn_error.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_construct_dsn_error.phpt
@@ -11,7 +11,7 @@ require_once("MsSetup.inc");
 //dsn with 2 consecutive semicolons
 try 
 {   
-    $conn = new PDO( "sqlsrv:Server = $server;;", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server = $server;Encrypt=$encrypt;;", $uid, $pwd );
 }
 catch( PDOException $e ) {
     print_r( ($e->errorInfo)[2] );
@@ -21,7 +21,7 @@ catch( PDOException $e ) {
 //dsn with double right curly braces
 try 
 {   
-    $conn = new PDO( "sqlsrv:Server =$server; database = {tempdb}}", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server =$server;Encrypt=$encrypt; database = {tempdb}}", $uid, $pwd );
 }
 catch( PDOException $e ) {
     print_r( ($e->errorInfo)[2] );
@@ -31,7 +31,7 @@ catch( PDOException $e ) {
 //dsn with double right curly braces and semicolon
 try 
 {   
-    $conn = new PDO( "sqlsrv:Server =$server; database = {tempdb}};", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server =$server;Encrypt=$encrypt; database = {tempdb}};", $uid, $pwd );
 }
 catch( PDOException $e ) {
     print_r( ($e->errorInfo)[2] );
@@ -41,7 +41,7 @@ catch( PDOException $e ) {
 //dsn with right curly braces and other symbol
 try 
 {   
-    $conn = new PDO( "sqlsrv:Server =$server; database = {tempdb}?", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server =$server;Encrypt=$encrypt; database = {tempdb}?", $uid, $pwd );
 }
 catch( PDOException $e ) {
     print_r( ($e->errorInfo)[2] );
@@ -51,7 +51,7 @@ catch( PDOException $e ) {
 //dsn with no equal sign in one option
 try 
 {   
-    $conn = new PDO( "sqlsrv:Server =$server; database", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server =$server;Encrypt=$encrypt; database", $uid, $pwd );
 }
 catch( PDOException $e ) {
     print_r( ($e->errorInfo)[2] );
@@ -72,7 +72,7 @@ catch( PDOException $e ) {
 try 
 {   
     $databaseName = "tempdb";
-    @$conn = new PDO( "sqlsrv:database = $databaseName", $uid, $pwd );
+    @$conn = new PDO( "sqlsrv:database = $databaseName;Encrypt=$encrypt", $uid, $pwd );
 }
 catch( PDOException $e ) {
     print_r( ($e->errorInfo)[2] );
@@ -85,19 +85,19 @@ echo "\n";
 try 
 {   
     //dsn with curly braces
-    $conn = new PDO( "sqlsrv:Server =$server; database = {tempdb}", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server =$server; database = {tempdb};Encrypt=$encrypt", $uid, $pwd );
     echo "value in curly braces OK\n";
     
     //dsn with curly braces and semicolon
-    @$conn = new PDO( "sqlsrv:Server =$server; database = {tempdb};", $uid, $pwd );
+    @$conn = new PDO( "sqlsrv:Server =$server; database = {tempdb};Encrypt=$encrypt;", $uid, $pwd );
     echo "value in curly braces followed by a semicolon OK\n";
     
     //dsn with curly braces and trailing spaces
-    @$conn = new PDO( "sqlsrv:Server =$server; database = {tempdb}    ", $uid, $pwd );
+    @$conn = new PDO( "sqlsrv:Server =$server;Encrypt=$encrypt; database = {tempdb}    ", $uid, $pwd );
     echo "value in curly braces followed by trailing spaces OK\n";
     
     //dsn with no value specified and ends with semicolon
-    $conn = new PDO( "sqlsrv:Server =$server; database = ;", $uid, $pwd );
+    $conn = new PDO( "sqlsrv:Server =$server;Encrypt=$encrypt; database = ;", $uid, $pwd );
     echo "dsn with no value specified and ends with semicolon OK\n";
 }
 catch( PDOException $e ) {

--- a/test/functional/setup/setup_dbs.py
+++ b/test/functional/setup/setup_dbs.py
@@ -14,6 +14,7 @@ def _is_mssqltools_v18():
     try:
         result = subprocess.run(['bcp', '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         output = result.stdout + result.stderr
+        print("bcp version check:\n" + output)
         m = re.search(r'Version:\s*(\d+)', output)
         if m and int(m.group(1)) >= 18:
             return True
@@ -80,6 +81,8 @@ if __name__ == '__main__':
     base_conn = ' -S ' + server + ' -U ' + uid + ' -P ' + pwd + ' '
     conn_options_sqlcmd = base_conn + _encrypt_opt_sqlcmd
     conn_options_bcp = base_conn + _encrypt_opt_bcp
+    print("Connection options for sqlcmd: " + conn_options_sqlcmd)
+    print("Connection options for bcp: " + conn_options_bcp)
 
     # In Azure, assume an empty test database has been created using Azure portal
     if (args.AZURE.lower() == 'no'):

--- a/test/functional/setup/setup_dbs.py
+++ b/test/functional/setup/setup_dbs.py
@@ -11,16 +11,14 @@ from exec_sql_scripts import *
 def _is_mssqltools_v18():
     """Return True if mssql-tools >= 18 (encrypt mandatory by default)."""
     import subprocess, re
-    try:
-        result = subprocess.run(['bcp', '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        output = result.stdout + result.stderr
-        print("bcp version check:\n" + output)
-        m = re.search(r'Version:\s*(\d+)', output)
-        if m and int(m.group(1)) >= 18:
-            return True
-    except Exception:
-        pass
-    return False
+    result = subprocess.run(['bcp', '-v'], stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE, universal_newlines=True)
+    output = result.stdout + result.stderr
+    print("bcp version check:\n" + output)
+    m = re.search(r'Version:\s*(\d+)', output)
+    if m:
+        return int(m.group(1)) >= 18
+    raise RuntimeError("Failed to parse bcp version from output: " + output)
 
 # mssql-tools18 defaults to Encrypt=Mandatory.  The flags below add encrypt-
 # optional + trust-server-certificate so sqlcmd/bcp work against servers


### PR DESCRIPTION
This pull request updates the test and CI configuration to standardize the use of the `Encrypt` parameter in all PDO SQLSRV connection strings, removes legacy TrustServerCertificate patching logic from the macOS pipeline, and simplifies test skip logic. These changes improve maintainability of connection handling and test configuration for the SQLSRV and PDO_SQLSRV drivers.

**CI pipeline simplification and cleanup:**

* Removed all macOS-specific TrustServerCertificate patching and related test file modifications from the `azure-pipelines.yml` job scripts, as these are no longer required for ODBC 18 compatibility.
* Removed unnecessary test skip logic

**Database connection verification update:**

* The CI job for verifying database connectivity before tests no longer sets `TrustServerCertificate` in the connection options, relying only on the `Encrypt` parameter for connection setup.

**Test log and output processing improvements:**

* Updated the log processing step to always run `python3 output.py` and list XML files, and added commands to display `.diff` files for both drivers, improving visibility into test results and failures.