### PR TITLE
Add code coverage reporting to public pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -979,9 +979,9 @@ jobs:
       $env:VERSION = $jsondata.{$(phpVersion)}.version
       Write-Host "Latest PHP $(phpVersion) is ${env:VERSION}"
       cd $(Build.SourcesDirectory)\buildscripts\
-      python builddrivers.py --PHPVER=${env:VERSION} --DRIVER=sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
+      python -u builddrivers.py --PHPVER=${env:VERSION} --DRIVER=sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
       if ($LASTEXITCODE -ne 0) { throw "sqlsrv build failed" }
-      python builddrivers.py --PHPVER=${env:VERSION} --DRIVER=pdo_sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
+      python -u builddrivers.py --PHPVER=${env:VERSION} --DRIVER=pdo_sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
       if ($LASTEXITCODE -ne 0) { throw "pdo_sqlsrv build failed" }
       Write-Host "Listing built DLLs:"
       dir *sqlsrv*.dll
@@ -1058,7 +1058,7 @@ jobs:
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(sqlsrv_db)
-      OpenCppCoverage --sources $(Build.SourcesDirectory)\source --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
     displayName: 'Run sqlsrv functional tests with coverage'
 
   - script: |
@@ -1068,7 +1068,7 @@ jobs:
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(pdo_sqlsrv_db)
-      OpenCppCoverage --sources $(Build.SourcesDirectory)\source --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
     displayName: 'Run pdo_sqlsrv functional tests with coverage'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -982,14 +982,24 @@ jobs:
       cd $(Build.SourcesDirectory)\buildscripts\
       python -u builddrivers.py --PHPVER=${env:VERSION} --DRIVER=sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
       if ($LASTEXITCODE -ne 0) { throw "sqlsrv build failed" }
+      Write-Host "List DLLs and PDBs:"
+      dir *.dll
+      dir *.pdb
+      # Copy sqlsrv DLL and PDB immediately (before pdo_sqlsrv build overwrites the build tree)
+      Write-Host "Copying sqlsrv DLL and PDB to C:\tools\php\ext\"
+      Copy-Item *sqlsrv*.dll C:\tools\php\ext\ -Verbose
+      Copy-Item *sqlsrv*.pdb C:\tools\php\ext\ -Verbose -ErrorAction SilentlyContinue
       python -u builddrivers.py --PHPVER=${env:VERSION} --DRIVER=pdo_sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
       if ($LASTEXITCODE -ne 0) { throw "pdo_sqlsrv build failed" }
-      Write-Host "Listing built DLLs:"
-      dir *sqlsrv*.dll
-      Write-Host "Copying DLLs to C:\tools\php\ext\"
-      Copy-Item *sqlsrv*.dll C:\tools\php\ext\ -Verbose
-      Write-Host "Verifying DLLs in destination:"
-      dir C:\tools\php\ext\*sqlsrv*.dll
+      Write-Host "List DLLs and PDBs:"
+      dir *.dll
+      dir *.pdb
+      # Copy pdo_sqlsrv DLL and PDB
+      Write-Host "Copying pdo_sqlsrv DLL and PDB to C:\tools\php\ext\"
+      Copy-Item *pdo_sqlsrv*.dll C:\tools\php\ext\ -Verbose
+      Copy-Item *pdo_sqlsrv*.pdb C:\tools\php\ext\ -Verbose -ErrorAction SilentlyContinue
+      Write-Host "Verifying DLLs and PDBs in destination:"
+      dir C:\tools\php\ext\*sqlsrv*
       
       # Add extensions to php.ini
       Write-Host "Adding extensions to php.ini"
@@ -1182,13 +1192,15 @@ jobs:
           print(f'Using {coverage_files[0][0]} coverage as final report')
           sys.exit(0)
 
-      def normalize_windows_path(filename):
-          """Normalize Windows absolute PDB paths to match Linux relative paths.
+      def normalize_path(filename):
+          """Normalize paths so shared files from different drivers merge together.
           Windows: D:\\...\\ext\\sqlsrv\\conn.cpp -> sqlsrv/conn.cpp
           Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
-          Windows: D:\\...\\ext\\pdo_sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
+          Linux:   pdo_sqlsrv/shared/core_conn.cpp -> shared/core_conn.cpp
+          Linux:   sqlsrv/shared/core_conn.cpp -> shared/core_conn.cpp
           """
           f = filename.replace('\\', '/')
+          # Handle Windows absolute PDB paths
           m = re.search(r'/ext/((?:pdo_)?sqlsrv)/(.*)', f)
           if m:
               ext_name = m.group(1)
@@ -1196,6 +1208,10 @@ jobs:
               if rest.startswith('shared/'):
                   return rest
               return ext_name + '/' + rest
+          # Handle Linux relative paths: pdo_sqlsrv/shared/X or sqlsrv/shared/X -> shared/X
+          m = re.match(r'(?:pdo_)?sqlsrv/(shared/.*)', f)
+          if m:
+              return m.group(1)
           return f
 
       # Merge all files into a single coverage dict: filename -> {lineno: hits}
@@ -1210,8 +1226,7 @@ jobs:
           for pkg in tree.getroot().iter('package'):
               for cls in pkg.iter('class'):
                   fname = cls.get('filename', '')
-                  if platform == 'windows':
-                      fname = normalize_windows_path(fname)
+                  fname = normalize_path(fname)
                   if fname not in coverage_data:
                       coverage_data[fname] = {}
                       file_sources[fname] = set()
@@ -1325,6 +1340,7 @@ jobs:
       chmod +x codecov
       ./codecov --verbose upload-process \
         --fail-on-error \
+        --git-service github \
         -t $(codecov_token) \
         -n "merged" \
         -f $(Pipeline.Workspace)/coverage.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ pr:
 
 jobs:
 - job: macOS
+  condition: false
   pool:
     vmImage: 'macos-latest'
   timeoutInMinutes: 90
@@ -726,18 +727,35 @@ jobs:
     displayName: 'Run pdo_sqlsrv functional tests'
 
   - script: |
-      cd $(Build.SourcesDirectory)
-      echo -e "service_name: Azure Pipelines\n" > .coveralls.yml
-      coveralls -i ./source/ -e ./source/shared/ -e ./test/ -e ./source/pdo_sqlsrv/shared/core_stream.cpp \
-        -E r'.*localization*' -E r'.*globalization*' --gcov-options '\-lp'
-    displayName: 'Invoke coveralls using repo token'
-    condition: false
+      pip install gcovr
+      cd $(Build.SourcesDirectory)/source
+      gcovr --root . \
+        --filter 'sqlsrv/' --filter 'pdo_sqlsrv/' --filter 'shared/' \
+        --exclude '.*test/.*' \
+        --exclude '.*localization.*' --exclude '.*globalization.*' \
+        --cobertura -o $(Build.SourcesDirectory)/coverage.xml
+      echo "Coverage report generated:"
+      ls -la $(Build.SourcesDirectory)/coverage.xml
+    displayName: 'Collect code coverage'
+
+  - task: PublishCodeCoverageResults@2
+    displayName: 'Publish Code Coverage'
+    inputs:
+      summaryFileLocation: '$(Build.SourcesDirectory)/coverage.xml'
+
+  - script: |
+      curl -Os https://cli.codecov.io/latest/linux/codecov
+      chmod +x codecov
+      ./codecov --verbose upload-process \
+        --fail-on-error \
+        -t $(codecov_token) \
+        -n "Linux-PHP$(phpver)" \
+        -F linux \
+        -f $(Build.SourcesDirectory)/coverage.xml
+    displayName: 'Upload coverage to Codecov'
     env:
-      COVERALLS_REPO_TOKEN: $(repo_token)
-      TRAVIS_JOB_ID: $(Build.BuildId)
-      TRAVIS_BRANCH: $(Build.SourceBranchName)
-      PYTHONWARNINGS: ignore::yaml.YAMLLoadWarning
-     
+      CODECOV_TOKEN: $(codecov_token)
+
   - script: |
       docker logs -t $(host)
       cd $(Build.SourcesDirectory)/test/functional/
@@ -761,6 +779,7 @@ jobs:
     condition: always()
 
 - job: Windows
+  condition: false
   variables:
     phpVersion: 8.5
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1347,11 +1347,13 @@ jobs:
       chmod +x codecov
       ./codecov --verbose upload-process \
         --fail-on-error \
+        --disable-search \
         --git-service github \
         -t $(codecov_token) \
         -n "merged" \
-        -f $(Build.SourcesDirectory)/coverage.xml
+        -f coverage.xml
     displayName: 'Upload coverage to Codecov'
+    workingDirectory: '$(Build.SourcesDirectory)'
     env:
       CODECOV_TOKEN: $(codecov_token)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -524,11 +524,12 @@ jobs:
     condition: always()
 
 - job: Linux
-  condition: false
   variables:
     phpver: 8.5
   pool:
-    vmImage: 'ubuntu-22.04'
+    name: 'PHP-1ES-Public'
+    demands:
+      - ImageOverride -equals AzurePipelines-ubuntu-22.04
   steps:
   - checkout: self
     clean: true
@@ -733,24 +734,6 @@ jobs:
       echo "Coverage report generated:"
       ls -la $(Build.SourcesDirectory)/coverage.xml
     displayName: 'Collect code coverage'
-
-  - task: PublishCodeCoverageResults@2
-    displayName: 'Publish Code Coverage'
-    inputs:
-      summaryFileLocation: '$(Build.SourcesDirectory)/coverage.xml'
-
-  - script: |
-      curl -Os https://cli.codecov.io/latest/linux/codecov
-      chmod +x codecov
-      ./codecov --verbose upload-process \
-        --fail-on-error \
-        -t $(codecov_token) \
-        -n "Linux-PHP$(phpver)" \
-        -F linux \
-        -f $(Build.SourcesDirectory)/coverage.xml
-    displayName: 'Upload coverage to Codecov'
-    env:
-      CODECOV_TOKEN: $(codecov_token)
 
   - script: |
       docker logs -t $(host)
@@ -1111,25 +1094,6 @@ jobs:
       dir $(Build.SourcesDirectory)\coverage*
     displayName: 'Merge coverage reports'
 
-  - task: PublishCodeCoverageResults@2
-    displayName: 'Publish Code Coverage'
-    inputs:
-      summaryFileLocation: '$(Build.SourcesDirectory)\coverage.xml'
-
-  - powershell: |
-      Write-Host "Uploading coverage to Codecov..."
-      $ProgressPreference = 'SilentlyContinue'
-      Invoke-WebRequest -Uri 'https://cli.codecov.io/latest/windows/codecov.exe' -OutFile codecov.exe
-      .\codecov.exe --verbose upload-process `
-        --fail-on-error `
-        -t $(codecov_token) `
-        -n "Windows-PHP$(phpVersion)" `
-        -F windows `
-        -f $(Build.SourcesDirectory)\coverage.xml
-    displayName: 'Upload coverage to Codecov'
-    env:
-      CODECOV_TOKEN: $(codecov_token)
-
   - powershell: |
       $artifactDir = "$(Build.SourcesDirectory)\coverage-artifacts"
       New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
@@ -1151,4 +1115,235 @@ jobs:
       Write-Host "Stopping LocalDB..."
       sqllocaldb stop MSSQLLocalDB
     displayName: 'Cleanup LocalDB'
+    condition: always()
+
+- job: MergeCoverage
+  displayName: 'Merge Coverage Reports'
+  dependsOn:
+    - Linux
+    - Windows
+  condition: succeededOrFailed()
+  pool:
+    name: 'PHP-1ES-Public'
+    demands:
+      - ImageOverride -equals AzurePipelines-ubuntu-22.04
+  steps:
+  - checkout: none
+
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download Linux coverage'
+    inputs:
+      artifact: 'coverage-linux'
+      targetPath: '$(Pipeline.Workspace)/coverage-linux'
+    continueOnError: true
+
+  - task: DownloadPipelineArtifact@2
+    displayName: 'Download Windows coverage'
+    inputs:
+      artifact: 'coverage-windows'
+      targetPath: '$(Pipeline.Workspace)/coverage-windows'
+    continueOnError: true
+
+  - script: |
+      echo "=== Linux coverage artifacts ==="
+      ls -la $(Pipeline.Workspace)/coverage-linux/ 2>/dev/null || echo "No Linux coverage"
+      echo ""
+      echo "=== Windows coverage artifacts ==="
+      ls -la $(Pipeline.Workspace)/coverage-windows/ 2>/dev/null || echo "No Windows coverage"
+    displayName: 'List downloaded artifacts'
+
+  - script: |
+      pip install gcovr
+      python3 << 'PYEOF'
+      import xml.etree.ElementTree as ET
+      import os, sys, re, copy
+
+      workspace = os.environ['PIPELINE_WORKSPACE']
+      linux_xml = os.path.join(workspace, 'coverage-linux', 'coverage.xml')
+      windows_xml = os.path.join(workspace, 'coverage-windows', 'coverage.xml')
+
+      files = []
+      if os.path.exists(linux_xml):
+          files.append(('linux', linux_xml))
+          print(f'Found Linux coverage: {linux_xml}')
+      if os.path.exists(windows_xml):
+          files.append(('windows', windows_xml))
+          print(f'Found Windows coverage: {windows_xml}')
+
+      if not files:
+          print('No coverage files found')
+          sys.exit(1)
+
+      if len(files) == 1:
+          # Only one platform produced coverage - use it directly
+          import shutil
+          shutil.copy(files[0][1], os.path.join(workspace, 'coverage.xml'))
+          print(f'Using {files[0][0]} coverage as final report')
+          sys.exit(0)
+
+      def normalize_windows_path(filename):
+          """Normalize Windows absolute PDB paths to match Linux relative paths.
+          Windows: D:\\...\\ext\\sqlsrv\\conn.cpp -> sqlsrv/conn.cpp
+          Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
+          Windows: D:\\...\\ext\\pdo_sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
+          """
+          # Normalize separators
+          f = filename.replace('\\', '/')
+          # Extract path after ext/ (the PHP extension build directory)
+          m = re.search(r'/ext/((?:pdo_)?sqlsrv)/(.*)', f)
+          if m:
+              ext_name = m.group(1)  # sqlsrv or pdo_sqlsrv
+              rest = m.group(2)      # conn.cpp or shared/core_conn.cpp
+              # If it's under shared/, normalize to top-level shared/
+              if rest.startswith('shared/'):
+                  return rest
+              return ext_name + '/' + rest
+          return f
+
+      def normalize_class(cls, platform):
+          """Normalize class elements which contain the filename paths."""
+          if platform == 'windows':
+              filename = cls.get('filename', '')
+              cls.set('filename', normalize_windows_path(filename))
+          return cls
+
+      # Parse both files
+      linux_tree = ET.parse(linux_xml)
+      win_tree = ET.parse(windows_xml)
+
+      # Build a dict of filename -> class element from Linux (base)
+      linux_root = linux_tree.getroot()
+      coverage_data = {}  # filename -> {lines: {lineno: hits}}
+
+      for pkg in linux_root.iter('package'):
+          for cls in pkg.iter('class'):
+              fname = cls.get('filename', '')
+              if fname not in coverage_data:
+                  coverage_data[fname] = {}
+              for line in cls.iter('line'):
+                  num = line.get('number')
+                  hits = int(line.get('hits', '0'))
+                  coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
+
+      # Add Windows data with normalized paths
+      for pkg in win_tree.getroot().iter('package'):
+          for cls in pkg.iter('class'):
+              fname = normalize_windows_path(cls.get('filename', ''))
+              if fname not in coverage_data:
+                  coverage_data[fname] = {}
+              for line in cls.iter('line'):
+                  num = line.get('number')
+                  hits = int(line.get('hits', '0'))
+                  coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
+
+      # Build merged Cobertura XML
+      root = ET.Element('coverage')
+      root.set('version', '1')
+      root.set('timestamp', '0')
+      sources = ET.SubElement(root, 'sources')
+      source = ET.SubElement(sources, 'source')
+      source.text = '.'
+      packages = ET.SubElement(root, 'packages')
+
+      total_lines = 0
+      covered_lines = 0
+
+      # Group by directory (package)
+      pkg_data = {}
+      for fname, lines in sorted(coverage_data.items()):
+          pkg_name = os.path.dirname(fname) or '.'
+          if pkg_name not in pkg_data:
+              pkg_data[pkg_name] = {}
+          pkg_data[pkg_name][fname] = lines
+
+      for pkg_name, file_data in sorted(pkg_data.items()):
+          pkg_elem = ET.SubElement(packages, 'package')
+          pkg_elem.set('name', pkg_name)
+          classes = ET.SubElement(pkg_elem, 'classes')
+
+          pkg_lines = 0
+          pkg_covered = 0
+
+          for fname, lines in sorted(file_data.items()):
+              cls_elem = ET.SubElement(classes, 'class')
+              cls_elem.set('name', os.path.basename(fname))
+              cls_elem.set('filename', fname)
+              cls_elem.set('line-rate', '0')
+              cls_elem.set('branch-rate', '0')
+              cls_elem.set('complexity', '0')
+              lines_elem = ET.SubElement(cls_elem, 'lines')
+
+              file_lines = 0
+              file_covered = 0
+              for num, hits in sorted(lines.items(), key=lambda x: int(x[0])):
+                  line_elem = ET.SubElement(lines_elem, 'line')
+                  line_elem.set('number', str(num))
+                  line_elem.set('hits', str(hits))
+                  file_lines += 1
+                  if hits > 0:
+                      file_covered += 1
+
+              if file_lines > 0:
+                  cls_elem.set('line-rate', f'{file_covered / file_lines:.4f}')
+
+              pkg_lines += file_lines
+              pkg_covered += file_covered
+
+          if pkg_lines > 0:
+              pkg_elem.set('line-rate', f'{pkg_covered / pkg_lines:.4f}')
+          else:
+              pkg_elem.set('line-rate', '0')
+
+          total_lines += pkg_lines
+          covered_lines += pkg_covered
+
+      if total_lines > 0:
+          root.set('line-rate', f'{covered_lines / total_lines:.4f}')
+      else:
+          root.set('line-rate', '0')
+      root.set('lines-valid', str(total_lines))
+      root.set('lines-covered', str(covered_lines))
+
+      out = os.path.join(workspace, 'coverage.xml')
+      tree = ET.ElementTree(root)
+      tree.write(out, xml_declaration=True, encoding='utf-8')
+
+      print(f'Merged coverage: {covered_lines}/{total_lines} lines covered '
+            f'({covered_lines/total_lines*100:.1f}%)' if total_lines > 0 else 'No lines')
+      print(f'Files: {len(coverage_data)}')
+      print(f'Written to: {out}')
+      PYEOF
+    displayName: 'Merge coverage reports'
+    env:
+      PIPELINE_WORKSPACE: $(Pipeline.Workspace)
+
+  - script: |
+      ls -la $(Pipeline.Workspace)/coverage.xml
+      echo "=== First 50 lines of merged report ==="
+      head -50 $(Pipeline.Workspace)/coverage.xml
+    displayName: 'Inspect merged coverage'
+
+  - task: PublishCodeCoverageResults@2
+    displayName: 'Publish Code Coverage'
+    inputs:
+      summaryFileLocation: '$(Pipeline.Workspace)/coverage.xml'
+
+  - script: |
+      curl -Os https://cli.codecov.io/latest/linux/codecov
+      chmod +x codecov
+      ./codecov --verbose upload-process \
+        --fail-on-error \
+        -t $(codecov_token) \
+        -n "merged" \
+        -f $(Pipeline.Workspace)/coverage.xml
+    displayName: 'Upload coverage to Codecov'
+    env:
+      CODECOV_TOKEN: $(codecov_token)
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish merged coverage artifact'
+    inputs:
+      targetPath: '$(Pipeline.Workspace)/coverage.xml'
+      artifact: 'coverage-merged'
+      publishLocation: 'pipeline'
     condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -524,6 +524,7 @@ jobs:
     condition: always()
 
 - job: Linux
+  condition: false
   variables:
     phpver: 8.5
   pool:
@@ -582,11 +583,6 @@ jobs:
       odbcinst -j
       odbcinst -q -d -n "ODBC Driver 18 for SQL Server"
     displayName: 'Install ODBC Driver 18'
-
-  - powershell: |
-      $guid = [guid]::NewGuid().ToString()
-      Write-Host "##vso[task.setvariable variable=pwd;issecret=true]$guid"
-    displayName: 'Generate Password'
 
   - powershell: |
       $guid = [guid]::NewGuid().ToString()
@@ -779,7 +775,6 @@ jobs:
     condition: always()
 
 - job: Windows
-  condition: false
   variables:
     phpVersion: 8.5
   pool:
@@ -1042,23 +1037,33 @@ jobs:
       Write-Host "================================="
     displayName: 'Show ODBC Driver version being used'
 
+  - powershell: |
+      Write-Host "Installing OpenCppCoverage..."
+      choco install opencppcoverage -y
+      $env:Path = "C:\Program Files\OpenCppCoverage;$env:Path"
+      OpenCppCoverage --help | Select-Object -First 3
+      Write-Host "OpenCppCoverage installed successfully"
+    displayName: 'Install OpenCppCoverage'
+
   - script: |
+      set PATH=C:\Program Files\OpenCppCoverage;%PATH%
       cd $(Build.SourcesDirectory)\test\functional\sqlsrv
       set MSSQL_SERVER=(localdb)\MSSQLLocalDB
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(sqlsrv_db)
-      php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
-    displayName: 'Run sqlsrv functional tests'
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\source --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
+    displayName: 'Run sqlsrv functional tests with coverage'
 
   - script: |
+      set PATH=C:\Program Files\OpenCppCoverage;%PATH%
       cd $(Build.SourcesDirectory)\test\functional\pdo_sqlsrv
       set MSSQL_SERVER=(localdb)\MSSQLLocalDB
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(pdo_sqlsrv_db)
-      php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
-    displayName: 'Run pdo_sqlsrv functional tests'
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\source --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
+    displayName: 'Run pdo_sqlsrv functional tests with coverage'
 
   - script: |
       cd $(Build.SourcesDirectory)\test\functional\
@@ -1078,6 +1083,64 @@ jobs:
       testResultsFiles: '*.xml'
       failTaskOnFailedTests: true
       searchFolder: '$(Build.SourcesDirectory)\test\functional\'
+
+  - powershell: |
+      Write-Host "Merging coverage reports..."
+      pip install gcovr
+      
+      # Use Python to merge the Cobertura XML files
+      python -c @"
+      import xml.etree.ElementTree as ET
+      import sys, os
+      
+      files = [f for f in ['$(Build.SourcesDirectory)\coverage-sqlsrv.xml', '$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml'] if os.path.exists(f)]
+      if not files:
+          print('No coverage files found')
+          sys.exit(1)
+      
+      if len(files) == 1:
+          import shutil
+          shutil.copy(files[0], '$(Build.SourcesDirectory)\coverage.xml')
+      else:
+          # Simple merge: take first file as base, append packages from second
+          tree1 = ET.parse(files[0])
+          tree2 = ET.parse(files[1])
+          root1 = tree1.getroot()
+          packages1 = root1.find('.//packages')
+          if packages1 is None:
+              packages1 = root1.find('packages')
+          packages2 = tree2.getroot().find('.//packages')
+          if packages2 is None:
+              packages2 = tree2.getroot().find('packages')
+          if packages2 is not None and packages1 is not None:
+              for pkg in packages2:
+                  packages1.append(pkg)
+          tree1.write('$(Build.SourcesDirectory)\coverage.xml', xml_declaration=True, encoding='utf-8')
+      
+      print('Merged coverage written to coverage.xml')
+      "@
+      
+      dir $(Build.SourcesDirectory)\coverage*.xml
+    displayName: 'Merge coverage reports'
+
+  - task: PublishCodeCoverageResults@2
+    displayName: 'Publish Code Coverage'
+    inputs:
+      summaryFileLocation: '$(Build.SourcesDirectory)\coverage.xml'
+
+  - powershell: |
+      Write-Host "Uploading coverage to Codecov..."
+      $ProgressPreference = 'SilentlyContinue'
+      Invoke-WebRequest -Uri 'https://cli.codecov.io/latest/windows/codecov.exe' -OutFile codecov.exe
+      .\codecov.exe --verbose upload-process `
+        --fail-on-error `
+        -t $(codecov_token) `
+        -n "Windows-PHP$(phpVersion)" `
+        -F windows `
+        -f $(Build.SourcesDirectory)\coverage.xml
+    displayName: 'Upload coverage to Codecov'
+    env:
+      CODECOV_TOKEN: $(codecov_token)
 
   - powershell: |
       Write-Host "Stopping LocalDB..."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -541,6 +541,14 @@ jobs:
       architecture: 'x64'
 
   - script: |
+      echo "Configuring the Microsoft Package Repository (PMC)..."
+      # Download/Install the package to configure the Microsoft repo before installing PHP or the ODBC driver
+      curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+      sudo dpkg -i packages-microsoft-prod.deb
+      rm packages-microsoft-prod.deb
+      sudo apt-get update
+
+  - script: |
       echo "Installing PHP $(phpver) and dependencies..."
       # Add ondrej/php PPA for PHP 8.5
       sudo add-apt-repository ppa:ondrej/php -y
@@ -565,11 +573,6 @@ jobs:
 
   - script: |
       echo "Installing ODBC Driver 18 and dependencies..."
-      # Download/Install the package to configure the Microsoft repo
-      curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
-      sudo dpkg -i packages-microsoft-prod.deb
-      rm packages-microsoft-prod.deb
-      sudo apt-get update
       sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
       
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -778,7 +778,9 @@ jobs:
   variables:
     phpVersion: 8.5
   pool:
-    vmImage: 'windows-latest'
+    name: 'PHP-1ES-Public'
+    demands:
+      - ImageOverride -equals AzurePipelines-Windows-latest
   steps:
   - checkout: self
     clean: true
@@ -1041,7 +1043,8 @@ jobs:
       Write-Host "Installing OpenCppCoverage..."
       choco install opencppcoverage -y
       $env:Path = "C:\Program Files\OpenCppCoverage;$env:Path"
-      OpenCppCoverage --help | Select-Object -First 3
+      # Use & operator because --help returns non-zero exit code
+      & OpenCppCoverage --help 2>&1 | Select-Object -First 3
       Write-Host "OpenCppCoverage installed successfully"
     displayName: 'Install OpenCppCoverage'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1189,7 +1189,7 @@ jobs:
 
       if len(coverage_files) == 1:
           import shutil
-          shutil.copy(coverage_files[0][1], os.path.join(workspace, 'coverage.xml'))
+          shutil.copy(coverage_files[0][1], os.path.join(os.environ['BUILD_SOURCESDIRECTORY'], 'coverage.xml'))
           print(f'Using {coverage_files[0][0]} coverage as final report')
           sys.exit(0)
 
@@ -1316,7 +1316,7 @@ jobs:
       root.set('lines-valid', str(total_lines))
       root.set('lines-covered', str(covered_lines))
 
-      out = os.path.join(workspace, 'coverage.xml')
+      out = os.path.join(os.environ['BUILD_SOURCESDIRECTORY'], 'coverage.xml')
       tree = ET.ElementTree(root)
       ET.indent(tree, space='  ')
       tree.write(out, xml_declaration=True, encoding='utf-8')
@@ -1329,17 +1329,18 @@ jobs:
     displayName: 'Merge coverage reports'
     env:
       PIPELINE_WORKSPACE: $(Pipeline.Workspace)
+      BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
 
   - script: |
-      ls -la $(Pipeline.Workspace)/coverage.xml
+      ls -la $(Build.SourcesDirectory)/coverage.xml
       echo "=== First 50 lines of merged report ==="
-      head -50 $(Pipeline.Workspace)/coverage.xml
+      head -50 $(Build.SourcesDirectory)/coverage.xml
     displayName: 'Inspect merged coverage'
 
   - task: PublishCodeCoverageResults@2
     displayName: 'Publish Code Coverage'
     inputs:
-      summaryFileLocation: '$(Pipeline.Workspace)/coverage.xml'
+      summaryFileLocation: '$(Build.SourcesDirectory)/coverage.xml'
 
   - script: |
       curl -Os https://cli.codecov.io/latest/linux/codecov
@@ -1349,7 +1350,7 @@ jobs:
         --git-service github \
         -t $(codecov_token) \
         -n "merged" \
-        -f $(Pipeline.Workspace)/coverage.xml
+        -f $(Build.SourcesDirectory)/coverage.xml
     displayName: 'Upload coverage to Codecov'
     env:
       CODECOV_TOKEN: $(codecov_token)
@@ -1357,7 +1358,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     displayName: 'Publish merged coverage artifact'
     inputs:
-      targetPath: '$(Pipeline.Workspace)/coverage.xml'
+      targetPath: '$(Build.SourcesDirectory)/coverage.xml'
       artifact: 'coverage-merged'
       publishLocation: 'pipeline'
     condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -564,26 +564,22 @@ jobs:
     displayName: 'Install PHP $(phpver)'
 
   - script: |
-      echo "=== Diagnosing ODBC/unixODBC state ==="
-      echo "--- packages-microsoft-prod ---"
-      dpkg -s packages-microsoft-prod 2>&1 || true
-      echo "--- Installed ODBC-related packages ---"
-      dpkg -l | grep -iE 'odbc|unixodbc' || true
-      echo "--- Microsoft repo list files ---"
-      ls -la /etc/apt/sources.list.d/ || true
-      cat /etc/apt/sources.list.d/microsoft-prod.list 2>/dev/null || true
-      cat /etc/apt/sources.list.d/*.list 2>/dev/null || true
-      echo "--- APT policy for unixodbc-related packages ---"
-      apt-cache policy unixodbc-dev unixodbc unixodbc-common libodbc1 libodbc2 libodbcinst2 odbcinst1debian2 2>&1 || true
-      echo "--- APT policy for msodbcsql18 ---"
-      apt-cache policy msodbcsql18 2>&1 || true
-      echo "--- msodbcsql18 dependencies ---"
-      apt-cache show msodbcsql18 2>&1 | grep -iE '^Package:|^Version:|^Depends:|^Pre-Depends:' || true
-      echo "--- Simulate install ---"
-      sudo apt-get install -y --simulate unixodbc-dev 2>&1 || true
-      echo "--- Simulate msodbcsql18 install ---"
-      sudo ACCEPT_EULA=Y apt-get install -y --simulate msodbcsql18 mssql-tools18 unixodbc-dev 2>&1 || true
-      echo "=== End diagnostics ==="
+      echo "Installing ODBC Driver 18 and dependencies..."
+      # 1ES images' Microsoft repos have priority 1001, causing apt to prefer
+      # unixodbc 2.3.7 from Microsoft over 2.3.9 from Ubuntu. Pin unixODBC
+      # packages to prefer Ubuntu's versions.
+      printf '%s\n' \
+        'Package: unixodbc unixodbc-dev unixodbc-common libodbc1 libodbc2 libodbcinst2 odbcinst odbcinst1debian2' \
+        'Pin: origin packages.microsoft.com' \
+        'Pin-Priority: 100' \
+        | sudo tee /etc/apt/preferences.d/unixodbc-pin
+      if ! dpkg -s packages-microsoft-prod &>/dev/null; then
+        curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+        sudo dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+      fi
+      sudo apt-get update
+      sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
       
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -526,9 +526,7 @@ jobs:
   variables:
     phpver: 8.5
   pool:
-    name: 'PHP-1ES-Public'
-    demands:
-      - ImageOverride -equals AzurePipelines-ubuntu-22.04
+    vmImage: 'ubuntu-22.04'
   steps:
   - checkout: self
     clean: true
@@ -765,9 +763,7 @@ jobs:
   variables:
     phpVersion: 8.5
   pool:
-    name: 'PHP-1ES-Public'
-    demands:
-      - ImageOverride -equals AzurePipelines-Windows-latest
+    vmImage: 'windows-latest'
   steps:
   - checkout: self
     clean: true
@@ -1085,9 +1081,7 @@ jobs:
     - Windows
   condition: succeededOrFailed()
   pool:
-    name: 'PHP-1ES-Public'
-    demands:
-      - ImageOverride -equals AzurePipelines-ubuntu-22.04
+    vmImage: 'ubuntu-22.04'
   steps:
   - checkout: self
     fetchDepth: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,6 @@ pr:
 
 jobs:
 - job: macOS
-  condition: false
   pool:
     vmImage: 'macos-latest'
   timeoutInMinutes: 90
@@ -690,19 +689,6 @@ jobs:
     displayName: 'Update test configuration files'
 
   - script: |
-      echo "=== ODBC Driver Configuration ==="
-      echo "Installed ODBC Drivers:"
-      odbcinst -q -d
-      echo ""
-      echo "ODBC Driver 18 details:"
-      odbcinst -q -d -n "ODBC Driver 18 for SQL Server"
-      echo ""
-      echo "Driver configured in MsSetup.inc:"
-      grep -E '^\$driver' $(Build.SourcesDirectory)/test/functional/sqlsrv/MsSetup.inc
-      echo "================================="
-    displayName: 'Show ODBC Driver version being used'
-
-  - script: |
       cd $(Build.SourcesDirectory)/test/functional/sqlsrv
       export MSSQL_SERVER='$(server)'
       export MSSQL_USER='$(uid)'
@@ -855,16 +841,6 @@ jobs:
       php -v
     displayName: 'Install PHP $(phpVersion)'
 
-  - script: |
-      dir C:\tools\php\php*
-      dir C:\tools\php\ext\
-      echo extension_dir=C:\tools\php\ext >> C:\tools\php\php.ini
-      php --ini
-      php -v
-      echo Checking PHP API version:
-      php -r "echo 'PHP API: ' . phpversion() . PHP_EOL; echo 'Thread Safety: ' . (PHP_ZTS ? 'enabled' : 'disabled') . PHP_EOL; echo 'Architecture: ' . PHP_INT_SIZE*8 . '-bit' . PHP_EOL;"
-    displayName: 'Check PHP'
-
   - powershell: |
       $guid = [guid]::NewGuid().ToString()
       Write-Host "##vso[task.setvariable variable=pwd;issecret=true]$guid"
@@ -982,18 +958,16 @@ jobs:
       cd $(Build.SourcesDirectory)\buildscripts\
       python -u builddrivers.py --PHPVER=${env:VERSION} --DRIVER=sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
       if ($LASTEXITCODE -ne 0) { throw "sqlsrv build failed" }
-      Write-Host "List DLLs and PDBs:"
-      dir *.dll
-      dir *.pdb
+      Write-Host "Listing built DLLs and PDBs:"
+      dir *.dll,*.pdb
       # Copy sqlsrv DLL and PDB immediately (before pdo_sqlsrv build overwrites the build tree)
       Write-Host "Copying sqlsrv DLL and PDB to C:\tools\php\ext\"
       Copy-Item *sqlsrv*.dll C:\tools\php\ext\ -Verbose
       Copy-Item *sqlsrv*.pdb C:\tools\php\ext\ -Verbose -ErrorAction SilentlyContinue
       python -u builddrivers.py --PHPVER=${env:VERSION} --DRIVER=pdo_sqlsrv --ARCH=x64 --THREAD=nts --SOURCE=$(Build.SourcesDirectory)\source --TESTING --NO_RENAME
       if ($LASTEXITCODE -ne 0) { throw "pdo_sqlsrv build failed" }
-      Write-Host "List DLLs and PDBs:"
-      dir *.dll
-      dir *.pdb
+      Write-Host "Listing built DLLs and PDBs:"
+      dir *.dll,*.pdb
       # Copy pdo_sqlsrv DLL and PDB
       Write-Host "Copying pdo_sqlsrv DLL and PDB to C:\tools\php\ext\"
       Copy-Item *pdo_sqlsrv*.dll C:\tools\php\ext\ -Verbose
@@ -1010,15 +984,6 @@ jobs:
       Write-Host "Verifying extensions:"
       php --ri sqlsrv
       php --ri pdo_sqlsrv
-      
-      # Check DLL dependencies with dumpbin (optional, for diagnostics)
-      Write-Host "Checking DLL dependencies with dumpbin:"
-      $dumpbinPath = Get-ChildItem "C:\Program Files\Microsoft Visual Studio\2022\*\VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
-      if ($dumpbinPath) {
-          & $dumpbinPath.FullName /dependents C:\tools\php\ext\php_sqlsrv.dll | Select-String -Pattern "dll"
-      } else {
-          Write-Host "dumpbin.exe not found - skipping DLL dependency check"
-      }
       
       # Copy run-tests.php to test directories
       Copy-Item $(Build.SourcesDirectory)\buildscripts\php-sdk\phpdev\vs17\x64\php-${env:VERSION}-src\run-tests.php $(Build.SourcesDirectory)\test\functional\sqlsrv -Verbose
@@ -1041,16 +1006,6 @@ jobs:
     displayName: 'Set up test databases'
 
   - powershell: |
-      Write-Host "=== ODBC Driver Configuration ==="
-      Write-Host "Installed SQL Server ODBC Drivers:"
-      Get-OdbcDriver | Where-Object { $_.Name -like "*SQL Server*" } | Format-Table Name, Platform -AutoSize
-      Write-Host ""
-      Write-Host "Driver configured in MsSetup.inc:"
-      Select-String -Path "$(Build.SourcesDirectory)\test\functional\sqlsrv\MsSetup.inc" -Pattern '^\$driver'
-      Write-Host "================================="
-    displayName: 'Show ODBC Driver version being used'
-
-  - powershell: |
       Write-Host "Installing OpenCppCoverage..."
       choco install opencppcoverage -y
       $env:Path = "C:\Program Files\OpenCppCoverage;$env:Path"
@@ -1070,7 +1025,7 @@ jobs:
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(sqlsrv_db)
       OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
-    displayName: 'Run sqlsrv functional tests with coverage'
+    displayName: 'Run sqlsrv functional tests'
 
   - script: |
       set PATH=C:\Program Files\OpenCppCoverage;%PATH%
@@ -1080,7 +1035,7 @@ jobs:
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(pdo_sqlsrv_db)
       OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
-    displayName: 'Run pdo_sqlsrv functional tests with coverage'
+    displayName: 'Run pdo_sqlsrv functional tests'
 
   - script: |
       cd $(Build.SourcesDirectory)\test\functional\
@@ -1152,190 +1107,10 @@ jobs:
     continueOnError: true
 
   - script: |
-      echo "=== Linux coverage artifacts ==="
-      ls -la $(Pipeline.Workspace)/coverage-linux/ 2>/dev/null || echo "No Linux coverage"
-      echo ""
-      echo "=== Windows coverage artifacts ==="
-      ls -la $(Pipeline.Workspace)/coverage-windows/ 2>/dev/null || echo "No Windows coverage"
-    displayName: 'List downloaded artifacts'
-
-  - script: |
-      pip install gcovr
-      python3 << 'PYEOF'
-      import xml.etree.ElementTree as ET
-      import os, sys, re, glob
-
-      workspace = os.environ['PIPELINE_WORKSPACE']
-
-      # Collect all coverage XML files from both platforms
-      coverage_files = []
-      
-      # Linux: single coverage.xml
-      linux_xml = os.path.join(workspace, 'coverage-linux', 'coverage.xml')
-      if os.path.exists(linux_xml):
-          coverage_files.append(('linux', linux_xml))
-          print(f'Found Linux coverage: {linux_xml}')
-
-      # Windows: separate per-driver XMLs (coverage-sqlsrv.xml, coverage-pdo_sqlsrv.xml)
-      win_dir = os.path.join(workspace, 'coverage-windows')
-      if os.path.isdir(win_dir):
-          for f in sorted(glob.glob(os.path.join(win_dir, 'coverage*.xml'))):
-              coverage_files.append(('windows', f))
-              print(f'Found Windows coverage: {f}')
-
-      if not coverage_files:
-          print('No coverage files found')
-          sys.exit(1)
-
-      if len(coverage_files) == 1:
-          import shutil
-          shutil.copy(coverage_files[0][1], os.path.join(os.environ['BUILD_SOURCESDIRECTORY'], 'coverage.xml'))
-          print(f'Using {coverage_files[0][0]} coverage as final report')
-          sys.exit(0)
-
-      def normalize_path(filename):
-          """Normalize paths so shared files from different drivers merge together,
-          and prefix with source/ to match the repo layout.
-          Windows: D:\\...\\ext\\sqlsrv\\conn.cpp -> source/sqlsrv/conn.cpp
-          Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> source/shared/core_conn.cpp
-          Linux:   pdo_sqlsrv/shared/core_conn.cpp -> source/shared/core_conn.cpp
-          Linux:   sqlsrv/shared/core_conn.cpp -> source/shared/core_conn.cpp
-          """
-          f = filename.replace('\\', '/')
-          # Handle Windows absolute PDB paths
-          m = re.search(r'/ext/((?:pdo_)?sqlsrv)/(.*)', f)
-          if m:
-              ext_name = m.group(1)
-              rest = m.group(2)
-              if rest.startswith('shared/'):
-                  return 'source/' + rest
-              return 'source/' + ext_name + '/' + rest
-          # Handle Linux relative paths: pdo_sqlsrv/shared/X or sqlsrv/shared/X -> source/shared/X
-          m = re.match(r'(?:pdo_)?sqlsrv/(shared/.*)', f)
-          if m:
-              return 'source/' + m.group(1)
-          # Already has a driver prefix like sqlsrv/ or pdo_sqlsrv/
-          if re.match(r'(?:pdo_)?sqlsrv/', f):
-              return 'source/' + f
-          return f
-
-      # Merge all files into a single coverage dict: filename -> {lineno: hits}
-      # Also track which input files contributed to each source file
-      coverage_data = {}
-      file_sources = {}  # filename -> set of input xml basenames
-
-      for platform, xml_path in coverage_files:
-          input_label = f'{platform}:{os.path.basename(xml_path)}'
-          print(f'Processing: {xml_path}')
-          tree = ET.parse(xml_path)
-          for pkg in tree.getroot().iter('package'):
-              for cls in pkg.iter('class'):
-                  fname = cls.get('filename', '')
-                  fname = normalize_path(fname)
-                  if fname not in coverage_data:
-                      coverage_data[fname] = {}
-                      file_sources[fname] = set()
-                  file_sources[fname].add(input_label)
-                  for line in cls.iter('line'):
-                      num = line.get('number')
-                      hits = int(line.get('hits', '0'))
-                      coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
-
-      # Print per-file source summary for verification
-      print(f'\n=== Coverage merge summary: {len(coverage_data)} files ===')
-      for fname in sorted(coverage_data.keys()):
-          sources = ', '.join(sorted(file_sources[fname]))
-          lines_covered = sum(1 for h in coverage_data[fname].values() if h > 0)
-          lines_total = len(coverage_data[fname])
-          print(f'  {fname}: {lines_covered}/{lines_total} lines from [{sources}]')
-
-      # Build merged Cobertura XML
-      root = ET.Element('coverage')
-      root.set('version', '1')
-      root.set('timestamp', '0')
-      sources = ET.SubElement(root, 'sources')
-      source = ET.SubElement(sources, 'source')
-      source.text = '.'
-      packages = ET.SubElement(root, 'packages')
-
-      total_lines = 0
-      covered_lines = 0
-
-      pkg_data = {}
-      for fname, lines in sorted(coverage_data.items()):
-          pkg_name = os.path.dirname(fname) or '.'
-          if pkg_name not in pkg_data:
-              pkg_data[pkg_name] = {}
-          pkg_data[pkg_name][fname] = lines
-
-      for pkg_name, file_data in sorted(pkg_data.items()):
-          pkg_elem = ET.SubElement(packages, 'package')
-          pkg_elem.set('name', pkg_name)
-          classes = ET.SubElement(pkg_elem, 'classes')
-
-          pkg_lines = 0
-          pkg_covered = 0
-
-          for fname, lines in sorted(file_data.items()):
-              cls_elem = ET.SubElement(classes, 'class')
-              cls_elem.set('name', os.path.basename(fname))
-              cls_elem.set('filename', fname)
-              cls_elem.set('line-rate', '0')
-              cls_elem.set('branch-rate', '0')
-              cls_elem.set('complexity', '0')
-              lines_elem = ET.SubElement(cls_elem, 'lines')
-
-              file_lines = 0
-              file_covered = 0
-              for num, hits in sorted(lines.items(), key=lambda x: int(x[0])):
-                  line_elem = ET.SubElement(lines_elem, 'line')
-                  line_elem.set('number', str(num))
-                  line_elem.set('hits', str(hits))
-                  file_lines += 1
-                  if hits > 0:
-                      file_covered += 1
-
-              if file_lines > 0:
-                  cls_elem.set('line-rate', f'{file_covered / file_lines:.4f}')
-
-              pkg_lines += file_lines
-              pkg_covered += file_covered
-
-          if pkg_lines > 0:
-              pkg_elem.set('line-rate', f'{pkg_covered / pkg_lines:.4f}')
-          else:
-              pkg_elem.set('line-rate', '0')
-
-          total_lines += pkg_lines
-          covered_lines += pkg_covered
-
-      if total_lines > 0:
-          root.set('line-rate', f'{covered_lines / total_lines:.4f}')
-      else:
-          root.set('line-rate', '0')
-      root.set('lines-valid', str(total_lines))
-      root.set('lines-covered', str(covered_lines))
-
-      out = os.path.join(os.environ['BUILD_SOURCESDIRECTORY'], 'coverage.xml')
-      tree = ET.ElementTree(root)
-      ET.indent(tree, space='  ')
-      tree.write(out, xml_declaration=True, encoding='utf-8')
-
-      print(f'Merged coverage: {covered_lines}/{total_lines} lines covered '
-            f'({covered_lines/total_lines*100:.1f}%)' if total_lines > 0 else 'No lines')
-      print(f'Files: {len(coverage_data)}')
-      print(f'Written to: {out}')
-      PYEOF
+      python3 $(Build.SourcesDirectory)/buildscripts/merge_coverage.py \
+        '$(Pipeline.Workspace)' \
+        '$(Build.SourcesDirectory)'
     displayName: 'Merge coverage reports'
-    env:
-      PIPELINE_WORKSPACE: $(Pipeline.Workspace)
-      BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
-
-  - script: |
-      ls -la $(Build.SourcesDirectory)/coverage.xml
-      echo "=== First 50 lines of merged report ==="
-      head -50 $(Build.SourcesDirectory)/coverage.xml
-    displayName: 'Inspect merged coverage'
 
   - task: PublishCodeCoverageResults@2
     displayName: 'Publish Code Coverage'
@@ -1345,7 +1120,7 @@ jobs:
   - script: |
       curl -Os https://cli.codecov.io/latest/linux/codecov
       chmod +x codecov
-      ./codecov --verbose upload-process \
+      ./codecov upload-process \
         --fail-on-error \
         --disable-search \
         --git-service github \
@@ -1356,11 +1131,3 @@ jobs:
     workingDirectory: '$(Build.SourcesDirectory)'
     env:
       CODECOV_TOKEN: $(codecov_token)
-
-  - task: PublishPipelineArtifact@1
-    displayName: 'Publish merged coverage artifact'
-    inputs:
-      targetPath: '$(Build.SourcesDirectory)/coverage.xml'
-      artifact: 'coverage-merged'
-      publishLocation: 'pipeline'
-    condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -541,14 +541,6 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      echo "Configuring the Microsoft Package Repository (PMC)..."
-      # Download/Install the package to configure the Microsoft repo before installing PHP or the ODBC driver
-      curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
-      sudo dpkg -i packages-microsoft-prod.deb
-      rm packages-microsoft-prod.deb
-      sudo apt-get update
-
-  - script: |
       echo "Installing PHP $(phpver) and dependencies..."
       # Add ondrej/php PPA for PHP 8.5
       sudo add-apt-repository ppa:ondrej/php -y
@@ -573,16 +565,20 @@ jobs:
 
   - script: |
       echo "Installing ODBC Driver 18 and dependencies..."
+      # Only install packages-microsoft-prod if not already present at a newer
+      # version. The 1ES image ships with v1.2 which configures repos compatible
+      # with unixODBC 2.3.9; downloading v1.0 downgrades it and breaks the repo
+      # config, causing dependency conflicts between libodbc2 and libodbc1.
+      if ! dpkg -s packages-microsoft-prod &>/dev/null; then
+        curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+        sudo dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
+      fi
+      sudo apt-get update
       sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
       
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
-      
-      # Note: Not configuring system-wide ODBC connection pooling
-      # The system-wide pooling configuration (Pooling=Yes, CPTimeout) causes
-      # extreme overhead for tests that disconnect/reconnect frequently.
-      # Tests that need pooling (like sqlsrv_ConnPool_Unix.phpt) explicitly
-      # enable it in their connection strings with ConnectionPooling=1.
       
       odbcinst -j
       odbcinst -q -d -n "ODBC Driver 18 for SQL Server"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -565,16 +565,18 @@ jobs:
 
   - script: |
       echo "Installing ODBC Driver 18 and dependencies..."
-      # Only install packages-microsoft-prod if not already present at a newer
-      # version. The 1ES image ships with v1.2 which configures repos compatible
-      # with unixODBC 2.3.9; downloading v1.0 downgrades it and breaks the repo
-      # config, causing dependency conflicts between libodbc2 and libodbc1.
+      # Only install packages-microsoft-prod if not already present
       if ! dpkg -s packages-microsoft-prod &>/dev/null; then
         curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
         sudo dpkg -i packages-microsoft-prod.deb
         rm packages-microsoft-prod.deb
+        sudo apt-get update
       fi
-      sudo apt-get update
+      # Install unixodbc-dev first so libodbc2 (2.3.9 on Ubuntu 22.04) is present before
+      # msodbcsql18. When libodbc2 is already installed, apt can resolve
+      # msodbcsql18's libodbc1 dependency without pulling in the conflicting
+      # 2.3.7 package.
+      sudo apt-get install -y unixodbc-dev
       sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
       
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1095,18 +1095,22 @@ jobs:
       pip install gcovr
       
       # Use Python to merge the Cobertura XML files
+      # Note: use forward slashes to avoid Python escape sequence issues (\a = bell, etc.)
+      $srcDir = "$(Build.SourcesDirectory)" -replace '\\','/'
       python -c @"
       import xml.etree.ElementTree as ET
       import sys, os
       
-      files = [f for f in ['$(Build.SourcesDirectory)\coverage-sqlsrv.xml', '$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml'] if os.path.exists(f)]
+      src = '$srcDir'
+      files = [f for f in [src + '/coverage-sqlsrv.xml', src + '/coverage-pdo_sqlsrv.xml'] if os.path.exists(f)]
       if not files:
           print('No coverage files found')
           sys.exit(1)
       
+      out = src + '/coverage.xml'
       if len(files) == 1:
           import shutil
-          shutil.copy(files[0], '$(Build.SourcesDirectory)\coverage.xml')
+          shutil.copy(files[0], out)
       else:
           # Simple merge: take first file as base, append packages from second
           tree1 = ET.parse(files[0])
@@ -1121,7 +1125,7 @@ jobs:
           if packages2 is not None and packages1 is not None:
               for pkg in packages2:
                   packages1.append(pkg)
-          tree1.write('$(Build.SourcesDirectory)\coverage.xml', xml_declaration=True, encoding='utf-8')
+          tree1.write(out, xml_declaration=True, encoding='utf-8')
       
       print('Merged coverage written to coverage.xml')
       "@

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1043,9 +1043,12 @@ jobs:
       Write-Host "Installing OpenCppCoverage..."
       choco install opencppcoverage -y
       $env:Path = "C:\Program Files\OpenCppCoverage;$env:Path"
-      # Use & operator because --help returns non-zero exit code
-      & OpenCppCoverage --help 2>&1 | Select-Object -First 3
-      Write-Host "OpenCppCoverage installed successfully"
+      # Verify install by checking the executable exists
+      if (Test-Path "C:\Program Files\OpenCppCoverage\OpenCppCoverage.exe") {
+          Write-Host "OpenCppCoverage installed successfully"
+      } else {
+          throw "OpenCppCoverage executable not found"
+      }
     displayName: 'Install OpenCppCoverage'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -564,20 +564,26 @@ jobs:
     displayName: 'Install PHP $(phpver)'
 
   - script: |
-      echo "Installing ODBC Driver 18 and dependencies..."
-      # Only install packages-microsoft-prod if not already present
-      if ! dpkg -s packages-microsoft-prod &>/dev/null; then
-        curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
-        sudo dpkg -i packages-microsoft-prod.deb
-        rm packages-microsoft-prod.deb
-        sudo apt-get update
-      fi
-      # Install unixodbc-dev first so libodbc2 (2.3.9 on Ubuntu 22.04) is present before
-      # msodbcsql18. When libodbc2 is already installed, apt can resolve
-      # msodbcsql18's libodbc1 dependency without pulling in the conflicting
-      # 2.3.7 package.
-      sudo apt-get install -y unixodbc-dev
-      sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev
+      echo "=== Diagnosing ODBC/unixODBC state ==="
+      echo "--- packages-microsoft-prod ---"
+      dpkg -s packages-microsoft-prod 2>&1 || true
+      echo "--- Installed ODBC-related packages ---"
+      dpkg -l | grep -iE 'odbc|unixodbc' || true
+      echo "--- Microsoft repo list files ---"
+      ls -la /etc/apt/sources.list.d/ || true
+      cat /etc/apt/sources.list.d/microsoft-prod.list 2>/dev/null || true
+      cat /etc/apt/sources.list.d/*.list 2>/dev/null || true
+      echo "--- APT policy for unixodbc-related packages ---"
+      apt-cache policy unixodbc-dev unixodbc unixodbc-common libodbc1 libodbc2 libodbcinst2 odbcinst1debian2 2>&1 || true
+      echo "--- APT policy for msodbcsql18 ---"
+      apt-cache policy msodbcsql18 2>&1 || true
+      echo "--- msodbcsql18 dependencies ---"
+      apt-cache show msodbcsql18 2>&1 | grep -iE '^Package:|^Version:|^Depends:|^Pre-Depends:' || true
+      echo "--- Simulate install ---"
+      sudo apt-get install -y --simulate unixodbc-dev 2>&1 || true
+      echo "--- Simulate msodbcsql18 install ---"
+      sudo ACCEPT_EULA=Y apt-get install -y --simulate msodbcsql18 mssql-tools18 unixodbc-dev 2>&1 || true
+      echo "=== End diagnostics ==="
       
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bash_profile
       echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1056,7 +1056,7 @@ jobs:
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(sqlsrv_db)
-      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type binary:$(Build.SourcesDirectory)\coverage-sqlsrv.cov -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
     displayName: 'Run sqlsrv functional tests with coverage'
 
   - script: |
@@ -1066,7 +1066,7 @@ jobs:
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(pdo_sqlsrv_db)
-      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type binary:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.cov -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
     displayName: 'Run pdo_sqlsrv functional tests with coverage'
 
   - script: |
@@ -1088,17 +1088,10 @@ jobs:
       failTaskOnFailedTests: true
       searchFolder: '$(Build.SourcesDirectory)\test\functional\'
 
-  - script: |
-      set PATH=C:\Program Files\OpenCppCoverage;%PATH%
-      OpenCppCoverage --input_coverage=$(Build.SourcesDirectory)\coverage-sqlsrv.cov --input_coverage=$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.cov --export_type cobertura:$(Build.SourcesDirectory)\coverage.xml
-      dir $(Build.SourcesDirectory)\coverage*
-    displayName: 'Merge coverage reports'
-
   - powershell: |
       $artifactDir = "$(Build.SourcesDirectory)\coverage-artifacts"
       New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
       Copy-Item "$(Build.SourcesDirectory)\coverage*.xml" $artifactDir -ErrorAction SilentlyContinue
-      Copy-Item "$(Build.SourcesDirectory)\coverage*.cov" $artifactDir -ErrorAction SilentlyContinue
       dir $artifactDir
     displayName: 'Stage coverage artifacts'
     condition: always()
@@ -1156,29 +1149,34 @@ jobs:
       pip install gcovr
       python3 << 'PYEOF'
       import xml.etree.ElementTree as ET
-      import os, sys, re, copy
+      import os, sys, re, glob
 
       workspace = os.environ['PIPELINE_WORKSPACE']
+
+      # Collect all coverage XML files from both platforms
+      coverage_files = []
+      
+      # Linux: single coverage.xml
       linux_xml = os.path.join(workspace, 'coverage-linux', 'coverage.xml')
-      windows_xml = os.path.join(workspace, 'coverage-windows', 'coverage.xml')
-
-      files = []
       if os.path.exists(linux_xml):
-          files.append(('linux', linux_xml))
+          coverage_files.append(('linux', linux_xml))
           print(f'Found Linux coverage: {linux_xml}')
-      if os.path.exists(windows_xml):
-          files.append(('windows', windows_xml))
-          print(f'Found Windows coverage: {windows_xml}')
 
-      if not files:
+      # Windows: separate per-driver XMLs (coverage-sqlsrv.xml, coverage-pdo_sqlsrv.xml)
+      win_dir = os.path.join(workspace, 'coverage-windows')
+      if os.path.isdir(win_dir):
+          for f in sorted(glob.glob(os.path.join(win_dir, 'coverage*.xml'))):
+              coverage_files.append(('windows', f))
+              print(f'Found Windows coverage: {f}')
+
+      if not coverage_files:
           print('No coverage files found')
           sys.exit(1)
 
-      if len(files) == 1:
-          # Only one platform produced coverage - use it directly
+      if len(coverage_files) == 1:
           import shutil
-          shutil.copy(files[0][1], os.path.join(workspace, 'coverage.xml'))
-          print(f'Using {files[0][0]} coverage as final report')
+          shutil.copy(coverage_files[0][1], os.path.join(workspace, 'coverage.xml'))
+          print(f'Using {coverage_files[0][0]} coverage as final report')
           sys.exit(0)
 
       def normalize_windows_path(filename):
@@ -1187,54 +1185,46 @@ jobs:
           Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
           Windows: D:\\...\\ext\\pdo_sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
           """
-          # Normalize separators
           f = filename.replace('\\', '/')
-          # Extract path after ext/ (the PHP extension build directory)
           m = re.search(r'/ext/((?:pdo_)?sqlsrv)/(.*)', f)
           if m:
-              ext_name = m.group(1)  # sqlsrv or pdo_sqlsrv
-              rest = m.group(2)      # conn.cpp or shared/core_conn.cpp
-              # If it's under shared/, normalize to top-level shared/
+              ext_name = m.group(1)
+              rest = m.group(2)
               if rest.startswith('shared/'):
                   return rest
               return ext_name + '/' + rest
           return f
 
-      def normalize_class(cls, platform):
-          """Normalize class elements which contain the filename paths."""
-          if platform == 'windows':
-              filename = cls.get('filename', '')
-              cls.set('filename', normalize_windows_path(filename))
-          return cls
+      # Merge all files into a single coverage dict: filename -> {lineno: hits}
+      # Also track which input files contributed to each source file
+      coverage_data = {}
+      file_sources = {}  # filename -> set of input xml basenames
 
-      # Parse both files
-      linux_tree = ET.parse(linux_xml)
-      win_tree = ET.parse(windows_xml)
+      for platform, xml_path in coverage_files:
+          input_label = f'{platform}:{os.path.basename(xml_path)}'
+          print(f'Processing: {xml_path}')
+          tree = ET.parse(xml_path)
+          for pkg in tree.getroot().iter('package'):
+              for cls in pkg.iter('class'):
+                  fname = cls.get('filename', '')
+                  if platform == 'windows':
+                      fname = normalize_windows_path(fname)
+                  if fname not in coverage_data:
+                      coverage_data[fname] = {}
+                      file_sources[fname] = set()
+                  file_sources[fname].add(input_label)
+                  for line in cls.iter('line'):
+                      num = line.get('number')
+                      hits = int(line.get('hits', '0'))
+                      coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
 
-      # Build a dict of filename -> class element from Linux (base)
-      linux_root = linux_tree.getroot()
-      coverage_data = {}  # filename -> {lines: {lineno: hits}}
-
-      for pkg in linux_root.iter('package'):
-          for cls in pkg.iter('class'):
-              fname = cls.get('filename', '')
-              if fname not in coverage_data:
-                  coverage_data[fname] = {}
-              for line in cls.iter('line'):
-                  num = line.get('number')
-                  hits = int(line.get('hits', '0'))
-                  coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
-
-      # Add Windows data with normalized paths
-      for pkg in win_tree.getroot().iter('package'):
-          for cls in pkg.iter('class'):
-              fname = normalize_windows_path(cls.get('filename', ''))
-              if fname not in coverage_data:
-                  coverage_data[fname] = {}
-              for line in cls.iter('line'):
-                  num = line.get('number')
-                  hits = int(line.get('hits', '0'))
-                  coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
+      # Print per-file source summary for verification
+      print(f'\n=== Coverage merge summary: {len(coverage_data)} files ===')
+      for fname in sorted(coverage_data.keys()):
+          sources = ', '.join(sorted(file_sources[fname]))
+          lines_covered = sum(1 for h in coverage_data[fname].values() if h > 0)
+          lines_total = len(coverage_data[fname])
+          print(f'  {fname}: {lines_covered}/{lines_total} lines from [{sources}]')
 
       # Build merged Cobertura XML
       root = ET.Element('coverage')
@@ -1248,7 +1238,6 @@ jobs:
       total_lines = 0
       covered_lines = 0
 
-      # Group by directory (package)
       pkg_data = {}
       for fname, lines in sorted(coverage_data.items()):
           pkg_name = os.path.dirname(fname) or '.'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1134,7 +1134,8 @@ jobs:
     demands:
       - ImageOverride -equals AzurePipelines-ubuntu-22.04
   steps:
-  - checkout: none
+  - checkout: self
+    fetchDepth: 1
 
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Linux coverage'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -920,21 +920,16 @@ jobs:
       Write-Host "Downloading ODBC Driver 18 for SQL Server..."
       $client = New-Object Net.WebClient
       # Download ODBC Driver 18 MSI
-      $client.DownloadFile('https://go.microsoft.com/fwlink/?linkid=2249006', '$(Build.SourcesDirectory)\msodbcsql.msi')
+      $client.DownloadFile('https://go.microsoft.com/fwlink/?linkid=2345415', '$(Build.SourcesDirectory)\msodbcsql.msi')
       Write-Host "Downloaded msodbcsql.msi"
-      dir $(Build.SourcesDirectory)\msodbcsql.msi
-    displayName: 'Download ODBC Driver 18 MSI'
 
-  - script: |
       cd $(Build.SourcesDirectory)
+      dir msodbcsql.msi
       msiexec /i "msodbcsql.msi" /q IACCEPTMSODBCSQLLICENSETERMS=YES ADDLOCAL=ALL
+
       echo "Verifying ODBC Driver 18 installation..."
       reg query "HKLM\SOFTWARE\ODBC\odbcinst.ini\ODBC Driver 18 for SQL Server"
       dir %WINDIR%\System32\msodbcsql*.dll
-    displayName: 'Install ODBC Driver 18'
-
-  - powershell: |
-      Write-Host "Verifying ODBC Driver 18 installation..."
       Get-OdbcDriver | Where-Object { $_.Name -like "*SQL Server*" } | Format-Table Name, Platform -AutoSize
       $driver18 = Get-OdbcDriver | Where-Object { $_.Name -eq "ODBC Driver 18 for SQL Server" }
       if (-not $driver18) {
@@ -942,7 +937,7 @@ jobs:
           exit 1
       }
       Write-Host "✓ ODBC Driver 18 for SQL Server installed successfully"
-    displayName: 'Verify ODBC Driver 18 installation'
+    displayName: 'Install ODBC Driver 18'
 
   - powershell: |
       $client = New-Object Net.WebClient
@@ -984,7 +979,7 @@ jobs:
       # Copy run-tests.php to test directories
       Copy-Item $(Build.SourcesDirectory)\buildscripts\php-sdk\phpdev\vs17\x64\php-${env:VERSION}-src\run-tests.php $(Build.SourcesDirectory)\test\functional\sqlsrv -Verbose
       Copy-Item $(Build.SourcesDirectory)\buildscripts\php-sdk\phpdev\vs17\x64\php-${env:VERSION}-src\run-tests.php $(Build.SourcesDirectory)\test\functional\pdo_sqlsrv -Verbose
-    displayName: 'Build drivers (separately) for the latest version of PHP $(phpVersion)'
+    displayName: 'Build drivers for PHP $(phpVersion)'
 
   - powershell: |
       Write-Host "Setting up test databases..."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -774,6 +774,21 @@ jobs:
     displayName: 'Stop SQL Server for Linux'
     condition: always()
 
+  - script: |
+      mkdir -p $(Build.SourcesDirectory)/coverage-artifacts
+      cp $(Build.SourcesDirectory)/coverage*.xml $(Build.SourcesDirectory)/coverage-artifacts/ 2>/dev/null || true
+      ls -la $(Build.SourcesDirectory)/coverage-artifacts/
+    displayName: 'Stage coverage artifacts'
+    condition: always()
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish coverage artifacts'
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)/coverage-artifacts'
+      artifact: 'coverage-linux'
+      publishLocation: 'pipeline'
+    condition: always()
+
 - job: Windows
   variables:
     phpVersion: 8.5
@@ -1058,7 +1073,7 @@ jobs:
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(sqlsrv_db)
-      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type binary:$(Build.SourcesDirectory)\coverage-sqlsrv.cov -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\sqlsrv.log
     displayName: 'Run sqlsrv functional tests with coverage'
 
   - script: |
@@ -1068,7 +1083,7 @@ jobs:
       set MSSQL_USER=$(uid)
       set MSSQL_PASSWORD=$(pwd)
       set MSSQL_DATABASE_NAME=$(pdo_sqlsrv_db)
-      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type cobertura:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.xml -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
+      OpenCppCoverage --sources $(Build.SourcesDirectory)\buildscripts --modules php_sqlsrv.dll --modules php_pdo_sqlsrv.dll --cover_children --export_type binary:$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.cov -- php run-tests.php *.phpt --no-color --show-diff 2>&1 | tee ..\pdo_sqlsrv.log
     displayName: 'Run pdo_sqlsrv functional tests with coverage'
 
   - script: |
@@ -1090,47 +1105,10 @@ jobs:
       failTaskOnFailedTests: true
       searchFolder: '$(Build.SourcesDirectory)\test\functional\'
 
-  - powershell: |
-      Write-Host "Merging coverage reports..."
-      pip install gcovr
-      
-      # Use Python to merge the Cobertura XML files
-      # Note: use forward slashes to avoid Python escape sequence issues (\a = bell, etc.)
-      $srcDir = "$(Build.SourcesDirectory)" -replace '\\','/'
-      python -c @"
-      import xml.etree.ElementTree as ET
-      import sys, os
-      
-      src = '$srcDir'
-      files = [f for f in [src + '/coverage-sqlsrv.xml', src + '/coverage-pdo_sqlsrv.xml'] if os.path.exists(f)]
-      if not files:
-          print('No coverage files found')
-          sys.exit(1)
-      
-      out = src + '/coverage.xml'
-      if len(files) == 1:
-          import shutil
-          shutil.copy(files[0], out)
-      else:
-          # Simple merge: take first file as base, append packages from second
-          tree1 = ET.parse(files[0])
-          tree2 = ET.parse(files[1])
-          root1 = tree1.getroot()
-          packages1 = root1.find('.//packages')
-          if packages1 is None:
-              packages1 = root1.find('packages')
-          packages2 = tree2.getroot().find('.//packages')
-          if packages2 is None:
-              packages2 = tree2.getroot().find('packages')
-          if packages2 is not None and packages1 is not None:
-              for pkg in packages2:
-                  packages1.append(pkg)
-          tree1.write(out, xml_declaration=True, encoding='utf-8')
-      
-      print('Merged coverage written to coverage.xml')
-      "@
-      
-      dir $(Build.SourcesDirectory)\coverage*.xml
+  - script: |
+      set PATH=C:\Program Files\OpenCppCoverage;%PATH%
+      OpenCppCoverage --input_coverage=$(Build.SourcesDirectory)\coverage-sqlsrv.cov --input_coverage=$(Build.SourcesDirectory)\coverage-pdo_sqlsrv.cov --export_type cobertura:$(Build.SourcesDirectory)\coverage.xml
+      dir $(Build.SourcesDirectory)\coverage*
     displayName: 'Merge coverage reports'
 
   - task: PublishCodeCoverageResults@2
@@ -1151,6 +1129,23 @@ jobs:
     displayName: 'Upload coverage to Codecov'
     env:
       CODECOV_TOKEN: $(codecov_token)
+
+  - powershell: |
+      $artifactDir = "$(Build.SourcesDirectory)\coverage-artifacts"
+      New-Item -ItemType Directory -Path $artifactDir -Force | Out-Null
+      Copy-Item "$(Build.SourcesDirectory)\coverage*.xml" $artifactDir -ErrorAction SilentlyContinue
+      Copy-Item "$(Build.SourcesDirectory)\coverage*.cov" $artifactDir -ErrorAction SilentlyContinue
+      dir $artifactDir
+    displayName: 'Stage coverage artifacts'
+    condition: always()
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish coverage artifacts'
+    inputs:
+      targetPath: '$(Build.SourcesDirectory)\coverage-artifacts'
+      artifact: 'coverage-windows'
+      publishLocation: 'pipeline'
+    condition: always()
 
   - powershell: |
       Write-Host "Stopping LocalDB..."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -922,14 +922,19 @@ jobs:
       # Download ODBC Driver 18 MSI
       $client.DownloadFile('https://go.microsoft.com/fwlink/?linkid=2345415', '$(Build.SourcesDirectory)\msodbcsql.msi')
       Write-Host "Downloaded msodbcsql.msi"
+      dir $(Build.SourcesDirectory)\msodbcsql.msi
+    displayName: 'Download ODBC Driver 18 MSI'
 
+  - script: |
       cd $(Build.SourcesDirectory)
-      dir msodbcsql.msi
       msiexec /i "msodbcsql.msi" /q IACCEPTMSODBCSQLLICENSETERMS=YES ADDLOCAL=ALL
-
       echo "Verifying ODBC Driver 18 installation..."
       reg query "HKLM\SOFTWARE\ODBC\odbcinst.ini\ODBC Driver 18 for SQL Server"
       dir %WINDIR%\System32\msodbcsql*.dll
+    displayName: 'Install ODBC Driver 18'
+
+  - powershell: |
+      Write-Host "Verifying ODBC Driver 18 installation..."
       Get-OdbcDriver | Where-Object { $_.Name -like "*SQL Server*" } | Format-Table Name, Platform -AutoSize
       $driver18 = Get-OdbcDriver | Where-Object { $_.Name -eq "ODBC Driver 18 for SQL Server" }
       if (-not $driver18) {
@@ -937,7 +942,7 @@ jobs:
           exit 1
       }
       Write-Host "✓ ODBC Driver 18 for SQL Server installed successfully"
-    displayName: 'Install ODBC Driver 18'
+    displayName: 'Verify ODBC Driver 18 installation'
 
   - powershell: |
       $client = New-Object Net.WebClient

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1193,11 +1193,12 @@ jobs:
           sys.exit(0)
 
       def normalize_path(filename):
-          """Normalize paths so shared files from different drivers merge together.
-          Windows: D:\\...\\ext\\sqlsrv\\conn.cpp -> sqlsrv/conn.cpp
-          Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> shared/core_conn.cpp
-          Linux:   pdo_sqlsrv/shared/core_conn.cpp -> shared/core_conn.cpp
-          Linux:   sqlsrv/shared/core_conn.cpp -> shared/core_conn.cpp
+          """Normalize paths so shared files from different drivers merge together,
+          and prefix with source/ to match the repo layout.
+          Windows: D:\\...\\ext\\sqlsrv\\conn.cpp -> source/sqlsrv/conn.cpp
+          Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> source/shared/core_conn.cpp
+          Linux:   pdo_sqlsrv/shared/core_conn.cpp -> source/shared/core_conn.cpp
+          Linux:   sqlsrv/shared/core_conn.cpp -> source/shared/core_conn.cpp
           """
           f = filename.replace('\\', '/')
           # Handle Windows absolute PDB paths
@@ -1206,12 +1207,15 @@ jobs:
               ext_name = m.group(1)
               rest = m.group(2)
               if rest.startswith('shared/'):
-                  return rest
-              return ext_name + '/' + rest
-          # Handle Linux relative paths: pdo_sqlsrv/shared/X or sqlsrv/shared/X -> shared/X
+                  return 'source/' + rest
+              return 'source/' + ext_name + '/' + rest
+          # Handle Linux relative paths: pdo_sqlsrv/shared/X or sqlsrv/shared/X -> source/shared/X
           m = re.match(r'(?:pdo_)?sqlsrv/(shared/.*)', f)
           if m:
-              return m.group(1)
+              return 'source/' + m.group(1)
+          # Already has a driver prefix like sqlsrv/ or pdo_sqlsrv/
+          if re.match(r'(?:pdo_)?sqlsrv/', f):
+              return 'source/' + f
           return f
 
       # Merge all files into a single coverage dict: filename -> {lineno: hits}
@@ -1313,6 +1317,7 @@ jobs:
 
       out = os.path.join(workspace, 'coverage.xml')
       tree = ET.ElementTree(root)
+      ET.indent(tree, space='  ')
       tree.write(out, xml_declaration=True, encoding='utf-8')
 
       print(f'Merged coverage: {covered_lines}/{total_lines} lines covered '

--- a/buildscripts/merge_coverage.py
+++ b/buildscripts/merge_coverage.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Merge cross-platform Cobertura XML coverage reports into a single report.
+
+Reads coverage XML files from Linux (gcovr) and Windows (OpenCppCoverage),
+normalizes file paths to match the repo layout, deduplicates shared source
+files, and writes a merged Cobertura XML.
+
+Usage:
+    python merge_coverage.py <workspace> <output_dir>
+    python merge_coverage.py  # falls back to PIPELINE_WORKSPACE / BUILD_SOURCESDIRECTORY env vars
+"""
+
+import argparse
+import xml.etree.ElementTree as ET
+import os
+import sys
+import re
+import glob
+import shutil
+
+
+def normalize_path(filename):
+    """Normalize paths so shared files from different drivers merge together,
+    and prefix with source/ to match the repo layout.
+
+    Windows: D:\\...\\ext\\sqlsrv\\conn.cpp -> source/sqlsrv/conn.cpp
+    Windows: D:\\...\\ext\\sqlsrv\\shared\\core_conn.cpp -> source/shared/core_conn.cpp
+    Linux:   pdo_sqlsrv/shared/core_conn.cpp -> source/shared/core_conn.cpp
+    Linux:   sqlsrv/shared/core_conn.cpp -> source/shared/core_conn.cpp
+    """
+    f = filename.replace('\\', '/')
+    # Handle Windows absolute PDB paths
+    m = re.search(r'/ext/((?:pdo_)?sqlsrv)/(.*)', f)
+    if m:
+        ext_name = m.group(1)
+        rest = m.group(2)
+        if rest.startswith('shared/'):
+            return 'source/' + rest
+        return 'source/' + ext_name + '/' + rest
+    # Handle Linux relative paths: pdo_sqlsrv/shared/X or sqlsrv/shared/X -> source/shared/X
+    m = re.match(r'(?:pdo_)?sqlsrv/(shared/.*)', f)
+    if m:
+        return 'source/' + m.group(1)
+    # Already has a driver prefix like sqlsrv/ or pdo_sqlsrv/
+    if re.match(r'(?:pdo_)?sqlsrv/', f):
+        return 'source/' + f
+    return f
+
+
+def collect_coverage_files(workspace):
+    """Find all coverage XML files from Linux and Windows artifacts."""
+    coverage_files = []
+
+    # Linux: single coverage.xml
+    linux_xml = os.path.join(workspace, 'coverage-linux', 'coverage.xml')
+    if os.path.exists(linux_xml):
+        coverage_files.append(('linux', linux_xml))
+        print(f'Found Linux coverage: {linux_xml}')
+
+    # Windows: separate per-driver XMLs (coverage-sqlsrv.xml, coverage-pdo_sqlsrv.xml)
+    win_dir = os.path.join(workspace, 'coverage-windows')
+    if os.path.isdir(win_dir):
+        for f in sorted(glob.glob(os.path.join(win_dir, 'coverage*.xml'))):
+            coverage_files.append(('windows', f))
+            print(f'Found Windows coverage: {f}')
+
+    return coverage_files
+
+
+def merge_coverage(coverage_files):
+    """Parse and merge coverage data from multiple XML files."""
+    coverage_data = {}
+    file_sources = {}
+
+    for platform, xml_path in coverage_files:
+        input_label = f'{platform}:{os.path.basename(xml_path)}'
+        print(f'Processing: {xml_path}')
+        tree = ET.parse(xml_path)
+        for pkg in tree.getroot().iter('package'):
+            for cls in pkg.iter('class'):
+                fname = cls.get('filename', '')
+                fname = normalize_path(fname)
+                if fname not in coverage_data:
+                    coverage_data[fname] = {}
+                    file_sources[fname] = set()
+                file_sources[fname].add(input_label)
+                for line in cls.iter('line'):
+                    num = line.get('number')
+                    hits = int(line.get('hits', '0'))
+                    coverage_data[fname][num] = coverage_data[fname].get(num, 0) + hits
+
+    return coverage_data, file_sources
+
+
+def write_cobertura_xml(coverage_data, output_path):
+    """Write merged coverage data as a Cobertura XML file."""
+    root = ET.Element('coverage')
+    root.set('version', '1')
+    root.set('timestamp', '0')
+    sources = ET.SubElement(root, 'sources')
+    source = ET.SubElement(sources, 'source')
+    source.text = '.'
+    packages = ET.SubElement(root, 'packages')
+
+    total_lines = 0
+    covered_lines = 0
+
+    pkg_data = {}
+    for fname, lines in sorted(coverage_data.items()):
+        pkg_name = os.path.dirname(fname) or '.'
+        if pkg_name not in pkg_data:
+            pkg_data[pkg_name] = {}
+        pkg_data[pkg_name][fname] = lines
+
+    for pkg_name, file_data in sorted(pkg_data.items()):
+        pkg_elem = ET.SubElement(packages, 'package')
+        pkg_elem.set('name', pkg_name)
+        classes = ET.SubElement(pkg_elem, 'classes')
+
+        pkg_lines = 0
+        pkg_covered = 0
+
+        for fname, lines in sorted(file_data.items()):
+            cls_elem = ET.SubElement(classes, 'class')
+            cls_elem.set('name', os.path.basename(fname))
+            cls_elem.set('filename', fname)
+            cls_elem.set('line-rate', '0')
+            cls_elem.set('branch-rate', '0')
+            cls_elem.set('complexity', '0')
+            lines_elem = ET.SubElement(cls_elem, 'lines')
+
+            file_lines = 0
+            file_covered = 0
+            for num, hits in sorted(lines.items(), key=lambda x: int(x[0])):
+                line_elem = ET.SubElement(lines_elem, 'line')
+                line_elem.set('number', str(num))
+                line_elem.set('hits', str(hits))
+                file_lines += 1
+                if hits > 0:
+                    file_covered += 1
+
+            if file_lines > 0:
+                cls_elem.set('line-rate', f'{file_covered / file_lines:.4f}')
+
+            pkg_lines += file_lines
+            pkg_covered += file_covered
+
+        if pkg_lines > 0:
+            pkg_elem.set('line-rate', f'{pkg_covered / pkg_lines:.4f}')
+        else:
+            pkg_elem.set('line-rate', '0')
+
+        total_lines += pkg_lines
+        covered_lines += pkg_covered
+
+    if total_lines > 0:
+        root.set('line-rate', f'{covered_lines / total_lines:.4f}')
+    else:
+        root.set('line-rate', '0')
+    root.set('lines-valid', str(total_lines))
+    root.set('lines-covered', str(covered_lines))
+
+    tree = ET.ElementTree(root)
+    ET.indent(tree, space='  ')
+    tree.write(output_path, xml_declaration=True, encoding='utf-8')
+
+    return total_lines, covered_lines
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Merge cross-platform Cobertura XML coverage reports.')
+    parser.add_argument('workspace', nargs='?',
+                        default=os.environ.get('PIPELINE_WORKSPACE'),
+                        help='Pipeline workspace root containing coverage-linux/ '
+                             'and coverage-windows/ directories '
+                             '(default: $PIPELINE_WORKSPACE)')
+    parser.add_argument('output_dir', nargs='?',
+                        default=os.environ.get('BUILD_SOURCESDIRECTORY'),
+                        help='Output directory for coverage.xml '
+                             '(default: $BUILD_SOURCESDIRECTORY)')
+    args = parser.parse_args()
+
+    if not args.workspace or not args.output_dir:
+        parser.error('workspace and output_dir are required '
+                     '(pass as arguments or set PIPELINE_WORKSPACE '
+                     'and BUILD_SOURCESDIRECTORY environment variables)')
+
+    workspace = args.workspace
+    output_path = os.path.join(args.output_dir, 'coverage.xml')
+
+    coverage_files = collect_coverage_files(workspace)
+
+    if not coverage_files:
+        print('No coverage files found')
+        sys.exit(1)
+
+    if len(coverage_files) == 1:
+        shutil.copy(coverage_files[0][1], output_path)
+        print(f'Using {coverage_files[0][0]} coverage as final report')
+        sys.exit(0)
+
+    coverage_data, file_sources = merge_coverage(coverage_files)
+
+    # Print per-file source summary
+    print(f'\n=== Coverage merge summary: {len(coverage_data)} files ===')
+    for fname in sorted(coverage_data.keys()):
+        sources = ', '.join(sorted(file_sources[fname]))
+        lines_covered = sum(1 for h in coverage_data[fname].values() if h > 0)
+        lines_total = len(coverage_data[fname])
+        print(f'  {fname}: {lines_covered}/{lines_total} lines from [{sources}]')
+
+    total_lines, covered_lines = write_cobertura_xml(coverage_data, output_path)
+
+    if total_lines > 0:
+        print(f'Merged coverage: {covered_lines}/{total_lines} lines covered '
+              f'({covered_lines/total_lines*100:.1f}%)')
+    else:
+        print('No lines')
+    print(f'Files: {len(coverage_data)}')
+    print(f'Written to: {output_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request introduces major improvements to code coverage collection, merging, and reporting in the CI pipeline for both Linux and Windows builds. The changes replace the previous Coveralls-based approach with Cobertura XML reports, implement artifact staging and publishing for coverage results, and add a new cross-platform coverage merging script. Several legacy diagnostic steps are removed for clarity and efficiency.

**Code coverage collection and reporting improvements:**

* Switched from Coveralls to Cobertura XML coverage reporting for both Linux and Windows builds. On Linux, coverage is collected using `gcovr`, and on Windows, coverage is collected using `OpenCppCoverage`. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L729-R723) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L1017-R1033)
* Added steps to stage and publish coverage artifacts for both platforms as pipeline artifacts, making coverage data available for downstream processing. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R747-R761) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R1055-R1127)
* Introduced a new `MergeCoverage` job that downloads coverage artifacts from both platforms, merges them using the new `buildscripts/merge_coverage.py` script, publishes the merged coverage report, and uploads it to Codecov. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R1055-R1127) [[2]](diffhunk://#diff-328dc162962ddce702354c5fa89c8f1131b1f8d29ed05f57b0d5b833f11f2bddR1-R225)
* Note: Code coverage isn't collected on macOS. (1) It would slow down the already slow macOS run. (2) There is zero driver code difference between Linux and macOS, which means the coverage result wouldn't change.

**Build and installation enhancements:**

* Improved ODBC driver installation on Linux by pinning `unixODBC` packages to prefer Ubuntu versions, avoiding conflicts with Microsoft repositories.
* Updated ODBC Driver 18 download URL for Windows to use the latest link, ensuring up-to-date driver installation.
* Refined Windows build steps to copy both DLLs and PDBs for `sqlsrv` and `pdo_sqlsrv` drivers, improving debugging and artifact completeness.

**Cleanup and simplification:**

* Removed legacy Coveralls steps and several diagnostic scripts (such as PHP checks and ODBC driver version displays) to streamline the pipeline and reduce noise. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L590-L594) [[2]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L691-L703) [[3]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L841-L850) [[4]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L987-R987) [[5]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L1017-R1033)

**New script for coverage merging:**

* Added `buildscripts/merge_coverage.py`, which normalizes file paths, deduplicates shared files, and merges Cobertura XML coverage reports from both Linux and Windows into a single unified report.

These changes modernize the CI pipeline's coverage reporting, improve artifact management, and simplify build steps, resulting in clearer, more actionable coverage metrics across platforms.