### PR TITLE
Add DevSkim and Cppcheck CI workflows for PR checks

### DIFF
--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -1,0 +1,51 @@
+name: C++ Lint
+
+on:
+  push:
+    branches: [ "dev", "release" ]
+    paths:
+      - 'source/**'
+  pull_request:
+    branches: [ "dev", "release" ]
+    paths:
+      - 'source/**'
+
+jobs:
+  cppcheck:
+    name: Cppcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        run: |
+          cppcheck \
+            --enable=warning,performance,portability \
+            --error-exitcode=1 \
+            --suppress=missingIncludeSystem \
+            --suppress=missingInclude \
+            --suppress=unknownMacro \
+            --suppress=varFuncNullUB \
+            --suppress=dangerousTypeCast \
+            --suppress=nullPointerRedundantCheck \
+            --suppress=nullPointerArithmeticRedundantCheck \
+            --suppress=duplInheritedMember \
+            --suppress=invalidPointerCast \
+            --suppress=rethrowNoCurrentException \
+            --suppress=identicalInnerCondition \
+            --suppress=containerOutOfBounds \
+            --suppress=negativeContainerIndex \
+            --suppress=uninitMemberVar \
+            --suppress=uninitDerivedMemberVar \
+            --suppress=useInitializationList \
+            --std=c++11 \
+            --force \
+            --inline-suppr \
+            -I source/shared \
+            source/shared \
+            source/sqlsrv \
+            source/pdo_sqlsrv

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,0 +1,29 @@
+name: DevSkim
+
+on:
+  push:
+    branches: [ "dev", "release" ]
+  pull_request:
+    branches: [ "dev", "release" ]
+  schedule:
+    - cron: '30 7 * * 1'
+
+jobs:
+  DevSkim:
+    name: DevSkim
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: devskim-results.sarif


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate code quality and security checks for C++ code. The first workflow introduces static analysis with Cppcheck on relevant source directories, and the second integrates the DevSkim security scanner, including scheduled runs and result uploads to GitHub Security.

**Automated code quality checks:**

* Added `.github/workflows/cpp-lint.yml` to run Cppcheck on `source/shared`, `source/sqlsrv`, and `source/pdo_sqlsrv` directories for pushes and pull requests to the `dev` and `release` branches, focusing on warnings, performance, and portability issues.

**Automated security scanning:**

* Added `.github/workflows/devskim.yml` to run the DevSkim security scanner on pushes, pull requests, and on a weekly schedule, with results uploaded to the GitHub Security tab.