### PR TITLE
CHORE: Daily-repo-status prompt - Specify focused actionable next steps 

### DIFF
--- a/.github/workflows/daily-repo-status.md
+++ b/.github/workflows/daily-repo-status.md
@@ -42,13 +42,24 @@ Create an upbeat daily status report for the repo as a GitHub issue.
 - Recent repository activity (issues, PRs, discussions, releases, code changes)
 - Progress tracking, goal reminders and highlights
 - Project status and recommendations
-- Actionable next steps for maintainers
 
 ## Style
 
 - Be positive, encouraging, and helpful 🌟
 - Use emojis moderately for engagement
 - Keep it concise - adjust length based on actual activity
+
+## Actionable Next Steps to Focus on
+
+- PRs idle >3 days awaiting review (list each with link and last activity)
+- Issues idle >3 days awaiting review (list each with link and last activity)
+- Issues with 5+ reactions and no assignee
+- Failing CI runs on the default branch in the last 24h
+
+Avoid:
+
+- Generic advice (e.g., "improve documentation")
+- Suggestions requiring info not in the data above
 
 ## Process
 


### PR DESCRIPTION
This pull request updates the guidelines for generating the daily status report in the `.github/workflows/daily-repo-status.md` file. The main change is a more detailed and focused section on actionable next steps for maintainers, specifying exactly which items to highlight and which types of advice to avoid.

Actionable next steps section improvements:

* Added a new section, "Actionable Next Steps to Focus on", specifying to list PRs and issues idle for more than 3 days, issues with 5+ reactions and no assignee, and recent failing CI runs.
* Clarified to avoid generic advice and suggestions that can't be supported by the available data.