### PR TITLE
Use paths-ignore in CodeQL.yml to exclude third-party php-sdk

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,16 +1,2 @@
-path_classifiers:
-  generated:
-    - "buildscripts/php-sdk"
-  test:
-    - "test"
-
-queries:
-  # Exclude all external PHP SDK source code
-  - exclude:
-      path:
-        - "buildscripts/php-sdk"
-  # Include only the SQLSRV and PDO_SQLSRV source files within the PHP SDK, where we drop them for compilation
-  - include:
-      path:
-        - "buildscripts/php-sdk/**/sqlsrv"
-        - "buildscripts/php-sdk/**/pdo_sqlsrv"
+paths-ignore:
+  - "buildscripts/php-sdk"


### PR DESCRIPTION
path_classifiers and queries exclude are not honored by the sdl-required query suite. Use paths-ignore to skip extraction entirely for the buildscripts/php-sdk directory.