### PR TITLE
Speed up tests targeting invalid servers

### DIFF
--- a/test/functional/pdo_sqlsrv/PDO21_Connection.phpt
+++ b/test/functional/pdo_sqlsrv/PDO21_Connection.phpt
@@ -15,7 +15,7 @@ try {
     // Invalid connection attempt => errors are expected
     $serverName="InvalidServerName";
 
-    $dsn = getDSN($serverName, $databaseName, $driver);
+    $dsn = getDSN($serverName, $databaseName, $driver, 'LoginTimeout=1');
     $conn1 = new PDO($dsn, $uid, $pwd, $connectionOptions);
     if ($conn1) {
         printf("Invalid connection attempt should have failed.\n");

--- a/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
@@ -37,7 +37,7 @@ function connectInvalidServer()
         unset($conn);
 
         // Try connecting to an invalid server, should get an exception from ODBC
-        $connectionInfo = "Authentication = ActiveDirectoryMsi; LoginTimeout = 1;";
+        $connectionInfo = "Authentication = ActiveDirectoryMsi; LoginTimeout = 3;";
         $testCase = 'invalidServer';
         try {
             $conn = new PDO("sqlsrv:server = invalidServer; $connectionInfo", null, null);
@@ -67,7 +67,7 @@ function connectInvalidServerWithUser()
         unset($conn);
 
         // Try connecting to an invalid server, should get an exception from ODBC
-        $connectionInfo = "Authentication = ActiveDirectoryMsi; LoginTimeout = 1;";
+        $connectionInfo = "Authentication = ActiveDirectoryMsi; LoginTimeout = 3;";
         $user = "user";
         $testCase = 'invalidServer';
         try {

--- a/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_azure_ad_managed_identity.phpt
@@ -37,7 +37,7 @@ function connectInvalidServer()
         unset($conn);
 
         // Try connecting to an invalid server, should get an exception from ODBC
-        $connectionInfo = "Authentication = ActiveDirectoryMsi;";
+        $connectionInfo = "Authentication = ActiveDirectoryMsi; LoginTimeout = 1;";
         $testCase = 'invalidServer';
         try {
             $conn = new PDO("sqlsrv:server = invalidServer; $connectionInfo", null, null);
@@ -67,7 +67,7 @@ function connectInvalidServerWithUser()
         unset($conn);
 
         // Try connecting to an invalid server, should get an exception from ODBC
-        $connectionInfo = "Authentication = ActiveDirectoryMsi;";
+        $connectionInfo = "Authentication = ActiveDirectoryMsi; LoginTimeout = 1;";
         $user = "user";
         $testCase = 'invalidServer';
         try {

--- a/test/functional/pdo_sqlsrv/pdo_construct_attr_errors.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_construct_attr_errors.phpt
@@ -34,7 +34,7 @@ function invalidServer()
     try {
         $options = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
         $invalid = pack("H*", "ffc0");
-        $conn = new PDO("sqlsrv:server = $invalid; Encrypt = $encrypt;", $uid, $pwd, $options);
+        $conn = new PDO("sqlsrv:server = $invalid; Encrypt = $encrypt; LoginTimeout = 1;", $uid, $pwd, $options);
         echo "Should have failed to connect to invalid server.\n";
     }  catch (PDOException $e) {
         $error1 = '*Login timeout expired';

--- a/test/functional/sqlsrv/TC21_Connection.phpt
+++ b/test/functional/sqlsrv/TC21_Connection.phpt
@@ -19,7 +19,7 @@ function connectionTest()
     setup();
 
     // Invalid connection attempt => errors are expected
-    $conn1 = sqlsrv_connect('InvalidServerName');
+    $conn1 = sqlsrv_connect('InvalidServerName', array('LoginTimeout' => 1));
     if ($conn1 === false) {
         handleErrors();
     } else {

--- a/test/functional/sqlsrv/sqlsrv_azure_ad_managed_identity.phpt
+++ b/test/functional/sqlsrv/sqlsrv_azure_ad_managed_identity.phpt
@@ -36,7 +36,7 @@ function connectInvalidServer()
     sqlsrv_close($conn);
 
     // Try connecting to an invalid server, should get an exception from ODBC
-    $connectionInfo = array("Authentication"=>"ActiveDirectoryMsi");
+    $connectionInfo = array("Authentication"=>"ActiveDirectoryMsi", "LoginTimeout" => 1);
     $conn = sqlsrv_connect('invalidServer', $connectionInfo);
     if ($conn) {
         fatalError("AzureAD Managed Identity test: expected to fail with invalidServer\n");

--- a/test/functional/sqlsrv/sqlsrv_azure_ad_service_principal.phpt
+++ b/test/functional/sqlsrv/sqlsrv_azure_ad_service_principal.phpt
@@ -89,7 +89,7 @@ function connectAzureDB($showException)
 }
 
 // Try connecting to an invalid server. Expect this to fail.
-$connectionInfo = array("Authentication"=>"ActiveDirectoryServicePrincipal");
+$connectionInfo = array("Authentication"=>"ActiveDirectoryServicePrincipal", "LoginTimeout" => 1);
 $conn = sqlsrv_connect('invalidServer', $connectionInfo);
 if ($conn) {
     fatalError("AzureAD Service Principal test: expected to fail with invalidServer\n");

--- a/test/functional/sqlsrv/sqlsrv_connStr.phpt
+++ b/test/functional/sqlsrv/sqlsrv_connStr.phpt
@@ -67,7 +67,7 @@ sqlsrv_close($c);
 
 // test an invalid server name in UTF-8
 $server_invalid = pack("H*", "ffc0");
-$c = sqlsrv_connect($server_invalid, array( 'Database' => 'test', 'CharacterSet' => 'utf-8' ));
+$c = sqlsrv_connect($server_invalid, array( 'Database' => 'test', 'CharacterSet' => 'utf-8', 'LoginTimeout' => 1 ));
 if ($c !== false) {
     fatalError("sqlsrv_connect(1) should have failed");
 }

--- a/test/functional/sqlsrv/sqlsrv_errors.phpt
+++ b/test/functional/sqlsrv/sqlsrv_errors.phpt
@@ -34,7 +34,7 @@ sqlsrv_close returns true even if an error happens.
 
     require('MsCommon.inc');
 
-    $conn = sqlsrv_connect("InvalidServerName", array( "Database" => "test" ));
+    $conn = sqlsrv_connect("InvalidServerName", array( "Database" => "test", "LoginTimeout" => 1 ));
     try {
         $result = sqlsrv_close($conn);
         if ($result !== false) {


### PR DESCRIPTION
Low hanging fruit to save a little time on test runs.

This pull request updates several functional tests for both `pdo_sqlsrv` and `sqlsrv` drivers to ensure that connection attempts to invalid servers fail quickly. The main change is the addition of a `LoginTimeout = 1` parameter to connection strings and options, which reduces the time spent waiting for a connection to fail when testing error handling. This will make the test suite run faster and more reliably when simulating failed connections.

Test reliability and speed improvements:

* Added `LoginTimeout = 1` to DSNs and connection options in multiple `pdo_sqlsrv` test files to ensure invalid server connection attempts fail quickly. [[1]](diffhunk://#diff-8f994f8c9c2f33dc46067b7c800cf4c5510fafbaacd7578677e5316d8626df7aL18-R18) [[2]](diffhunk://#diff-9474726feeb5336dc03293d493d9841892b5dde8d5f87d88428f49dd6e0ac874L40-R40) [[3]](diffhunk://#diff-9474726feeb5336dc03293d493d9841892b5dde8d5f87d88428f49dd6e0ac874L70-R70) [[4]](diffhunk://#diff-41f4d360cc213e8140e7741ee4275f75eb3950fcdb4b3891af8c2097f603ee75L37-R37)
* Updated `sqlsrv_connect` calls in several `sqlsrv` test files to include `'LoginTimeout' => 1` in the connection options for invalid server scenarios. [[1]](diffhunk://#diff-31caca27bfe7b8a04633960b6123b65f1a7ebe8e27a81c82e9b619531324fdc8L22-R22) [[2]](diffhunk://#diff-122c576b5da886b0ffd84ecf58a9c2bd90e34e7c36eeea28b0ae9754f273876aL39-R39) [[3]](diffhunk://#diff-be701fdd568dbee19b7b366a8b0e0138c0cb5a2f7cf33595293e9e93eca7e3e6L92-R92) [[4]](diffhunk://#diff-c6ae4a554320407c7442b72e77dc483b7f0fad5e02364f3bcec8be70343f44e9L70-R70) [[5]](diffhunk://#diff-37261ae4e6c56408c69d6a8dd230334c4451fa54773d663f8416e8a0e8c87e79L37-R37)