### PR TITLE
Potential fix for code scanning alert no. 76: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'source/**'
 
+permissions:
+  contents: read
+
 jobs:
   cppcheck:
     name: Cppcheck


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/msphpsql/security/code-scanning/76](https://github.com/microsoft/msphpsql/security/code-scanning/76)

Add an explicit `permissions` block in `.github/workflows/cpp-lint.yml` at the workflow root so it applies to all jobs (including `cppcheck`).  
For this workflow, the minimal required permission is:

- `contents: read`

This preserves existing functionality (checkout + linting) while enforcing least privilege and satisfying the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
