### PR TITLE
Fix | Parameterize PDO::lastInsertId() sequence-name lookup and fix non-ASCII sequence names

### DIFF
--- a/source/pdo_sqlsrv/pdo_dbh.cpp
+++ b/source/pdo_sqlsrv/pdo_dbh.cpp
@@ -34,8 +34,7 @@ namespace {
 
 const char LAST_INSERT_ID_QUERY[] = "SELECT @@IDENTITY;";
 const size_t LAST_INSERT_ID_BUFF_LEN = 50;    // size of the buffer to hold the string value of the last inserted id, which may be an int, bigint, decimal(p,0) or numeric(p,0)
-const char SEQUENCE_CURRENT_VALUE_QUERY[] = "SELECT current_value FROM sys.sequences WHERE name=N'%s'";
-const int LAST_INSERT_ID_QUERY_MAX_LEN = sizeof( SEQUENCE_CURRENT_VALUE_QUERY ) + SQL_MAX_SQLSERVERNAME + 2; // include the quotes
+const char SEQUENCE_CURRENT_VALUE_QUERY[] = "SELECT current_value FROM sys.sequences WHERE name=?";
 
 // List of PDO supported connection options.
 namespace PDOConnOptionNames {
@@ -1630,6 +1629,8 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
     char    idSTR[LAST_INSERT_ID_BUFF_LEN] = { '\0' };
     char*   str = NULL;
     SQLLEN  cbID = 0;
+    zval    name_z;
+    ZVAL_UNDEF(&name_z);
 
     try {
         sqlsrv_malloc_auto_ptr<SQLWCHAR> wsql_string;
@@ -1638,13 +1639,7 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
         if (name == NULL) {
             wsql_string = utf16_string_from_mbcs_string(SQLSRV_ENCODING_CHAR, LAST_INSERT_ID_QUERY, sizeof(LAST_INSERT_ID_QUERY), &wsql_len);
         } else {
-            char buffer[LAST_INSERT_ID_QUERY_MAX_LEN] = { '\0' };
-#if PHP_VERSION_ID < 80100
-            snprintf(buffer, LAST_INSERT_ID_QUERY_MAX_LEN, SEQUENCE_CURRENT_VALUE_QUERY, name);
-#else
-            snprintf(buffer, LAST_INSERT_ID_QUERY_MAX_LEN, SEQUENCE_CURRENT_VALUE_QUERY, ZSTR_VAL(name));
-#endif
-            wsql_string = utf16_string_from_mbcs_string(SQLSRV_ENCODING_CHAR, buffer, sizeof(buffer), &wsql_len);
+            wsql_string = utf16_string_from_mbcs_string(SQLSRV_ENCODING_CHAR, SEQUENCE_CURRENT_VALUE_QUERY, sizeof(SEQUENCE_CURRENT_VALUE_QUERY), &wsql_len);
         }
         CHECK_CUSTOM_ERROR(wsql_string == 0, driver_stmt, SQLSRV_ERROR_QUERY_STRING_ENCODING_TRANSLATE, get_last_error_message(), NULL) {
             throw core::CoreException();
@@ -1658,6 +1653,17 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
         driver_stmt = core_sqlsrv_create_stmt( driver_dbh, core::allocate_stmt<pdo_sqlsrv_stmt>, NULL /*options_ht*/, NULL /*valid_stmt_opts*/, pdo_sqlsrv_handle_stmt_error, &temp_stmt );
         driver_stmt->set_func( __FUNCTION__ );
 
+        // Bind the sequence name using a character parameter with the application-defined encoding
+        if (name != NULL) {
+#if PHP_VERSION_ID < 80100
+            ZVAL_STRING(&name_z, name);
+#else
+            ZVAL_STRINGL(&name_z, ZSTR_VAL(name), ZSTR_LEN(name));
+#endif
+            core_sqlsrv_bind_param( driver_stmt, 0 /*param_num*/, SQL_PARAM_INPUT, &name_z, SQLSRV_PHPTYPE_INVALID,
+                                    driver_dbh->encoding(), SQL_UNKNOWN_TYPE, SQLSRV_UNKNOWN_SIZE, 0 );
+        }
+
         // execute the last insert id query
         core::SQLExecDirectW( driver_stmt, wsql_string );
         core::SQLFetchScroll( driver_stmt, SQL_FETCH_NEXT, 0 );
@@ -1669,6 +1675,7 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
         }
 
         driver_stmt->~sqlsrv_stmt();
+        zval_ptr_dtor(&name_z);
     } catch( core::CoreException& ) {
         // restore error handling to its previous mode
         dbh->error_mode = static_cast<decltype(dbh->error_mode)>(prev_err_mode);
@@ -1682,6 +1689,7 @@ zend_string * pdo_sqlsrv_dbh_last_id(_Inout_ pdo_dbh_t *dbh, _In_ const zend_str
         if( driver_stmt ) {
             driver_stmt->~sqlsrv_stmt();
         }
+        zval_ptr_dtor(&name_z);
 #if PHP_VERSION_ID < 80100
         *len = 0;
         str = reinterpret_cast<char*>(sqlsrv_malloc(0, sizeof(char), 1));     // return an empty string with a null terminator

--- a/test/functional/pdo_sqlsrv/pdo_278_lastinsertid_seq.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_278_lastinsertid_seq.phpt
@@ -55,7 +55,22 @@ try {
         // defaults to $tableName2 -- because it returns the last inserted row id value
         $lastRow = $conn->lastInsertId();
 
-        if ($lastSeq == 3 && $lastRow == 1) {
+        // The sequence name passed to lastInsertId() is bound as a parameter. Verify
+        // a sequence whose name contains non-ASCII (Unicode) characters resolves
+        // correctly -- previously the name was interpreted using the system code page
+        // and such lookups could fail to match.
+        $unicodeSeq = 'séquence_Ñ_日本';
+        $conn->exec("IF OBJECT_ID(N'$unicodeSeq', 'SO') IS NOT NULL DROP SEQUENCE [$unicodeSeq]");
+        $conn->exec("CREATE SEQUENCE [$unicodeSeq] AS INTEGER START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 100");
+        $conn->query("SELECT NEXT VALUE FOR [$unicodeSeq]")->fetchColumn();
+        $lastUnicodeSeq = $conn->lastInsertId($unicodeSeq);
+
+        // Because the name is parameterized, a SQL-injection payload is treated as a
+        // literal sequence name: it matches no sequence and returns an empty string
+        // instead of altering the query.
+        $lastInjection = $conn->lastInsertId("x' UNION ALL SELECT DB_NAME()--");
+
+        if ($lastSeq == 3 && $lastRow == 1 && $lastUnicodeSeq == 1 && $lastInjection === '') {
             echo "Done\n";
         } else {
             echo "sequence value or identity does not match as expected\n";
@@ -63,6 +78,7 @@ try {
         dropTable($conn, $tableName1);
         dropTable($conn, $tableName2);
         $conn->exec("DROP SEQUENCE $sequenceName");
+        $conn->exec("DROP SEQUENCE [$unicodeSeq]");
         unset($stmt);
     }
     unset($conn);

--- a/test/functional/pdo_sqlsrv/pdo_278_lastinsertid_seq.phpt
+++ b/test/functional/pdo_sqlsrv/pdo_278_lastinsertid_seq.phpt
@@ -59,6 +59,10 @@ try {
         // a sequence whose name contains non-ASCII (Unicode) characters resolves
         // correctly -- previously the name was interpreted using the system code page
         // and such lookups could fail to match.
+        // The name literal below is UTF-8, so ensure the connection encoding is UTF-8
+        // for the Unicode DDL/DML and the lastInsertId() lookup regardless of the
+        // platform's system code page.
+        $conn->setAttribute(PDO::SQLSRV_ATTR_ENCODING, PDO::SQLSRV_ENCODING_UTF8);
         $unicodeSeq = 'séquence_Ñ_日本';
         $conn->exec("IF OBJECT_ID(N'$unicodeSeq', 'SO') IS NOT NULL DROP SEQUENCE [$unicodeSeq]");
         $conn->exec("CREATE SEQUENCE [$unicodeSeq] AS INTEGER START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 100");


### PR DESCRIPTION
## Summary

`PDO::lastInsertId($name)` looks up a sequence's current value via `SELECT current_value FROM sys.sequences WHERE name=...`. Previously the `$name` argument was interpolated directly into the query string with `snprintf("... WHERE name=N'%s'", name)`, and the resulting query was always encoded using the **system (ANSI) code page** (`SQLSRV_ENCODING_CHAR`).

This change parameterizes the lookup (binds `name` as a query parameter) and encodes it using the **connection's configured encoding** (UTF-8 by default for PDO). This fixes a functional bug and hardens the lookup against string-interpolation issues.

## Why

**1. Functional bug: non-ASCII sequence names**
`sys.sequences.name` is `sysname` (`nvarchar(128)`) and fully supports Unicode. Because the old code hard-coded the system code page when encoding the query+name, a sequence whose name contained non-ASCII characters could be
mis-encoded and fail to match — so `lastInsertId()` returned an empty result for a sequence that exists. Binding the name with `driver_dbh->encoding()` honors the connection encoding and resolves these names correctly.

**2. Defense in depth: parameterize instead of interpolate**
The name was concatenated into the SQL text. While `$name` is a developer-supplied schema identifier (not request-routed user input) — so this is **not** a remotely exploitable injection in normal usage (MSRC severity: None / CVSS 0.0) — parameterizing removes the string-interpolation entirely, which is the correct, safer pattern.

## Changes

**`source/pdo_sqlsrv/pdo_dbh.cpp`**
- Changed `SEQUENCE_CURRENT_VALUE_QUERY` from `... WHERE name=N'%s'` to `... WHERE name=?`.
- Removed the now-unused `LAST_INSERT_ID_QUERY_MAX_LEN` and the `snprintf` buffer construction.
- Bind `name` via `core_sqlsrv_bind_param(...)` using `driver_dbh->encoding()` (the connection encoding) instead of forcing
  `SQLSRV_ENCODING_CHAR`.
- Added `zval name_z` lifetime management with `zval_ptr_dtor` cleanup in both the success and catch paths (the CHAR binding references the zval's buffer until after `SQLExecDirectW`).
- Preserved the existing `PHP_VERSION_ID < 80100` branches for the `zend_string` vs. `char*` name representation.

**`test/functional/pdo_sqlsrv/pdo_278_lastinsertid_seq.phpt`**
- Added a **non-ASCII sequence name** case (`séquence_Ñ_日本`): creates and advances the sequence, then asserts `lastInsertId($unicodeName) == 1`. This exercises the encoding fix.
- Added an **injection-payload regression**: passes `x' UNION ALL SELECT DB_NAME()--` and asserts the result is strictly `''`, proving the payload is treated as a literal name rather than altering the query.
- Cleans up the new sequence; preserves the `--EXPECT-- Done` contract.

## Testing

Built the extension from source and ran the updated test against a local SQL Server 2022 container:

- **Patched build:** `Done` (pass).
- **Pre-fix build:** fails the new assertions (`sequence value or identity does not match as expected`), confirming the test detects both the non-ASCII regression and the interpolation behavior.
- Existing assertions (`lastInsertId('sequence1') == 3`, `lastInsertId() == 1`) continue to pass.
