### PR TITLE
Fix Windows ZTS shared-build LNK2001 on _tsrm_ls_cache

### DIFF
--- a/source/pdo_sqlsrv/config.w32
+++ b/source/pdo_sqlsrv/config.w32
@@ -49,7 +49,11 @@ if( PHP_PDO_SQLSRV != "no" ) {
                 }
             }
             ADD_EXTENSION_DEP('pdo_sqlsrv', 'pdo');
-            EXTENSION("pdo_sqlsrv", pdo_sqlsrv_src_class, PHP_PDO_SQLSRV_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+            // Do NOT pass /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 here. On ZTS (thread-safe) shared
+            // builds it makes pdo_init.cpp define _tsrm_ls_cache with C linkage while the shared
+            // core_*.cpp reference it with C++ linkage, causing LNK2001. Omitting it matches the
+            // Linux/macOS (config.m4) builds, which resolve the cache through the engine.
+            EXTENSION("pdo_sqlsrv", pdo_sqlsrv_src_class, PHP_PDO_SQLSRV_SHARED);
     } else {
         WARNING("pdo-sqlsrv not enabled; libraries and headers not found");
     }

--- a/source/sqlsrv/config.w32
+++ b/source/sqlsrv/config.w32
@@ -50,7 +50,11 @@ if( PHP_SQLSRV != "no" ) {
                 }
             }
             if (PHP_DEBUG != "yes") ADD_FLAG( "CFLAGS_SQLSRV", "/guard:cf /O2" );
-            EXTENSION("sqlsrv", sqlsrv_src_class , PHP_SQLSRV_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
+            // Do NOT pass /DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 here. On ZTS (thread-safe) shared
+            // builds it makes init.cpp define _tsrm_ls_cache with C linkage while the shared
+            // core_*.cpp reference it with C++ linkage, causing LNK2001. Omitting it matches the
+            // Linux/macOS (config.m4) builds, which resolve the cache through the engine.
+            EXTENSION("sqlsrv", sqlsrv_src_class , PHP_SQLSRV_SHARED);
     } else {
         WARNING("sqlsrv not enabled; libraries and headers not found");
     }


### PR DESCRIPTION
### Problem
Windows thread-safe (ZTS) shared builds fail to link:

    core_stmt.obj : error LNK2001: unresolved external symbol
    "void * _tsrm_ls_cache" (?_tsrm_ls_cache@@3PEAXEA)
    fatal error LNK1120: 1 unresolved externals

NTS builds and all Linux/macOS builds are unaffected.

### Root cause
A C vs C++ language-linkage mismatch on `_tsrm_ls_cache`, exposed only when
`ZEND_ENABLE_STATIC_TSRMLS_CACHE` is defined (config.w32 defines it; config.m4 does not):

- `init.cpp` / `pdo_init.cpp` include `php_*sqlsrv.h` (-> `php.h` -> `zend.h`) **inside**
  an `extern "C"` block, so `zend.h`'s file-scope `ZEND_TSRMLS_CACHE_EXTERN()` gives
  `_tsrm_ls_cache` **C linkage**, and `ZEND_TSRMLS_CACHE_DEFINE()` defines the **unmangled** symbol.
- `shared/core_sqlsrv.h` includes `php.h` **outside** `extern "C"`, so `core_stmt.cpp`
  (via `SQLSRV_G` -> `ZEND_MODULE_GLOBALS_ACCESSOR` -> `TSRMG_STATIC` -> `_tsrm_ls_cache`)
  references the **C++-mangled** `?_tsrm_ls_cache@@3PEAXEA`.
- Definition (C, unmangled) != reference (C++, mangled) -> LNK2001.

The define is applied consistently to every sqlsrv/pdo_sqlsrv translation unit, so the
failure is a linkage mismatch rather than a missing define. Merely relocating the define
within `config.w32` is a no-op; removing it is what changes the outcome.

### Fix
Remove `/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1` from both `EXTENSION()` calls. The Windows
shared build then resolves the TSRM cache through the engine (`tsrm_get_ls_cache()`),
matching the Linux/macOS `config.m4` builds and the Windows static build.
