### PR TITLE
Release 5.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+## 5.13.3 - 2026-08-07
+Updated PECL release packages. Here is the list of updates:
+
+### Added
+- Windows support for installing the drivers with [PIE](https://github.com/php/pie) (the PHP Installer for Extensions). PIE-based installation, introduced for Linux and macOS in 5.13.2, is now also available on Windows: `pie install microsoft/sqlsrv` and `pie install microsoft/pdo_sqlsrv`.
+
+### Limitations
+- No support for inout / output params when using sql_variant type
+- No support for inout / output params when formatting decimal values
+- In Linux and macOS, setlocale() only takes effect if it is invoked before the first connection. Attempting to set the locale after connecting will not work
+- Always Encrypted requires [MS ODBC Driver 17+](https://docs.microsoft.com/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server)
+  - Only Windows Certificate Store and Azure Key Vault are supported. Custom Keystores are not yet supported
+  - Issue [#716](https://github.com/Microsoft/msphpsql/issues/716) - With Always Encrypted enabled, named parameters in subqueries are not supported
+  - Issue [#1050](https://github.com/microsoft/msphpsql/issues/1050) - With Always Encrypted enabled, insertion requires the column list for any tables with identity columns
+  - [Always Encrypted limitations](https://docs.microsoft.com/sql/connect/php/using-always-encrypted-php-drivers#limitations-of-the-php-drivers-when-using-always-encrypted)
+
+### Known Issues
+- Connection pooling on Linux or macOS is not recommended with [unixODBC](http://www.unixodbc.org/) < 2.3.7
+- When pooling is enabled in Linux or macOS
+  - unixODBC <= 2.3.4 (Linux and macOS) might not return proper diagnostic information, such as error messages, warnings and informative messages
+  - due to this unixODBC bug, fetch large data (such as xml, binary) as streams as a workaround. See the examples [here](https://github.com/Microsoft/msphpsql/wiki/Features#pooling)
+
 ## 5.13.2 - 2026-07-29
 Updated PECL release packages. Here is the list of updates:
 

--- a/source/shared/version.h
+++ b/source/shared/version.h
@@ -27,7 +27,7 @@
 // Increase Patch for backward compatible fixes.
 #define SQLVERSION_MAJOR 5
 #define SQLVERSION_MINOR 13
-#define SQLVERSION_PATCH 2
+#define SQLVERSION_PATCH 3
 #define SQLVERSION_BUILD 0
 
 // For previews, set this constant to 1, 2 and so on. Otherwise, set it to 0
@@ -59,7 +59,7 @@
 #define _FILEVERSION            SQLVERSION_MAJOR,SQLVERSION_MINOR,SQLVERSION_PATCH,SQLVERSION_BUILD
 
 // PECL package version ('-' or '+' is not allowed) - to support Pickle do not use macros below
-#define PHP_SQLSRV_VERSION      "5.13.2"
-#define PHP_PDO_SQLSRV_VERSION  "5.13.2"
+#define PHP_SQLSRV_VERSION      "5.13.3"
+#define PHP_PDO_SQLSRV_VERSION  "5.13.3"
 
 #endif // VERSION_H


### PR DESCRIPTION
Release 5.13.3 of the Microsoft Drivers for PHP for SQL Server.

The only change in this release is added support for installing the drivers with **PIE** (the PHP Installer for Extensions) on **Windows**. PIE-based installation was introduced for Linux and macOS in 5.13.2 and is now also available on Windows:

- `pie install microsoft/sqlsrv`
- `pie install microsoft/pdo_sqlsrv`

Changes:
- Bumped version to 5.13.3 in `source/shared/version.h` (`SQLVERSION_PATCH`, `PHP_SQLSRV_VERSION`, `PHP_PDO_SQLSRV_VERSION`).
- Added a 5.13.3 section to `CHANGELOG.md`.